### PR TITLE
Use a more responsive gpg keyserver

### DIFF
--- a/docker/base/scripts/install_gosu.sh
+++ b/docker/base/scripts/install_gosu.sh
@@ -6,7 +6,7 @@ GOSU_VERSION=${GOSU_VERSION:-1.11}
 ARCH=${ARCH:-amd64}
 PREFIX=${PREFIX:-/usr/local}
 
-gpg --keyserver ha.pool.sks-keyservers.net \
+gpg --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
 curl -sSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH" -o /tmp/gosu


### PR DESCRIPTION
The previous one was timing out and stopping builds