### PR TITLE
Add iRODS 4.2.8 Ubuntu 18.04 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ builds where curl is later dropped.
 A base image with curl and gosu installed, intended for multi-stage
 builds where curl is later dropped.
 
+### base/ubuntu/18.04 ###
+
+A base image with curl and gosu installed, intended for multi-stage
+builds where curl is later dropped.
+
 ### conda/ubuntu/12.04 ###
 
 A Conda package-building image with Conda, conda-build and
@@ -25,7 +30,12 @@ of the box. To be used for running tests only.
 
 ### irods/ubuntu/16.04 ###
 
-This is a Docker image of a vanilla iRODS 4.2.5 server that works out
+This is a Docker image of a vanilla iRODS 4.2.7 server that works out
+of the box. To be used for running tests only.
+
+### irods/ubuntu/18.04 ###
+
+This is a Docker image of a vanilla iRODS 4.2.8 server that works out
 of the box. To be used for running tests only.
 
 ## Build in instructions ##

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,9 +6,10 @@ DOCKER_ARGS ?= --pull --no-cache # IMPORTANT to get security updates
 
 .PHONY: clean
 
-image_names := ub-12.04-base ub-16.04-base
+image_names := ub-12.04-base ub-16.04-base ub-18.04-base
 image_names += ub-12.04-conda
-image_names += ub-16.04-irods-4.2
+image_names += ub-16.04-irods-4.2.7
+image_names += ub-18.04-irods-4.2.8
 
 images := $(addsuffix .$(TAG), $(image_names))
 
@@ -30,6 +31,14 @@ ub-16.04-base.$(TAG): base/ubuntu/16.04/Dockerfile
 	--tag $(TAG_NAMESPACE)/ub-16.04-base:$(TAG) --file $< ./base
 	touch $@
 
+ub-18.04-base.$(TAG): base/ubuntu/18.04/Dockerfile
+	docker build $(DOCKER_ARGS) \
+	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
+	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--tag $(TAG_NAMESPACE)/ub-18.04-base:latest \
+	--tag $(TAG_NAMESPACE)/ub-18.04-base:$(TAG) --file $< ./base
+	touch $@
+
 ub-12.04-conda.$(TAG): conda/ubuntu/12.04/Dockerfile ub-12.04-base.$(TAG)
 	docker build $(DOCKER_ARGS) \
 	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
@@ -38,12 +47,20 @@ ub-12.04-conda.$(TAG): conda/ubuntu/12.04/Dockerfile ub-12.04-base.$(TAG)
 	--tag $(TAG_NAMESPACE)/ub-12.04-conda:$(TAG) --file $< ./conda
 	touch $@
 
-ub-16.04-irods-4.2.$(TAG): irods/ubuntu/16.04/Dockerfile ub-16.04-base.$(TAG)
+ub-16.04-irods-4.2.7.$(TAG): irods/ubuntu/16.04/Dockerfile ub-16.04-base.$(TAG)
 	docker build $(DOCKER_ARGS) \
 	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
 	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
-	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2:latest \
-	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2:$(TAG) --file $< ./irods
+	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2.7:latest \
+	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2.7:$(TAG) --file $< ./irods
+	touch $@
+
+ub-18.04-irods-4.2.8.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
+	docker build $(DOCKER_ARGS) \
+	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
+	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:latest \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:$(TAG) --file $< ./irods
 	touch $@
 
 clean:

--- a/docker/base/ubuntu/18.04/Dockerfile
+++ b/docker/base/ubuntu/18.04/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04 as installer
+
+ENV GOSU_VERSION=1.12
+
+COPY ./scripts /opt/docker/base/scripts
+
+RUN apt-get update && \
+    apt-get install -q -y \
+    apt-utils \
+    bzip2 \
+    ca-certificates \
+    curl \
+    gpg
+
+RUN GOSU_VERSION=$GOSU_VERSION /opt/docker/base/scripts/install_gosu.sh && \
+    chmod +x /opt/docker/base/scripts/docker-entrypoint.sh
+
+FROM ubuntu:18.04
+
+COPY --from=installer /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=installer /opt/docker/base/scripts/docker-entrypoint.sh \
+    /opt/docker/base/scripts/docker-entrypoint.sh
+
+ENTRYPOINT ["/opt/docker/base/scripts/docker-entrypoint.sh"]

--- a/docker/base/ubuntu/18.04/README.md
+++ b/docker/base/ubuntu/18.04/README.md
@@ -1,0 +1,2 @@
+A base image with curl and gosu installed, intended for multi-stage
+builds where curl is later dropped.

--- a/docker/irods/ubuntu/18.04/Dockerfile
+++ b/docker/irods/ubuntu/18.04/Dockerfile
@@ -1,0 +1,42 @@
+FROM wsinpg/ub-18.04-base:latest
+
+ARG IRODS_VERSION=4.2.8
+ARG IRODS_PACKAGES_URL=https://packages.irods.org
+ARG UBUNTU_RELEASE=bionic
+
+WORKDIR /opt/docker/irods
+
+COPY ./scripts/*.sh ./scripts/
+COPY ./config/* ./config/
+
+RUN apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    gpg \
+    gpg-agent \
+    curl && \
+    curl -sSL $IRODS_PACKAGES_URL/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] $IRODS_PACKAGES_URL/apt $UBUNTU_RELEASE main" | \
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    postgresql \
+    jq \
+    irods-server="$IRODS_VERSION" \
+    irods-runtime="$IRODS_VERSION" \
+    irods-database-plugin-postgres="$IRODS_VERSION" \
+    irods-icommands="$IRODS_VERSION" \
+    irods-dev="$IRODS_VERSION" && \
+    apt-get install -q -y -f && \
+    apt-get autoremove -q -y && \
+    apt-get clean -q -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN /opt/docker/irods/scripts/create_database.sh && \
+    /opt/docker/irods/scripts/configure_irods.sh
+
+EXPOSE 1247
+
+ENTRYPOINT []
+CMD ["/opt/docker/irods/scripts/start_irods.sh"]

--- a/docker/irods/ubuntu/18.04/README.md
+++ b/docker/irods/ubuntu/18.04/README.md
@@ -1,8 +1,8 @@
-# iRODS 4.2.7 Server
+# iRODS 4.2.8 Server
 
 **Not for use in production!**
 
-This is a Docker image of a vanilla iRODS 4.2.7 server that works out
+This is a Docker image of a vanilla iRODS 4.2.8 server that works out
 of the box. To be used for running tests only.
 
 The iRODS server starts with a single user 'irods' configured.
@@ -12,7 +12,7 @@ The iRODS server starts with a single user 'irods' configured.
 
 To run the container (with iCAT port binding to the host machine):
 
-`docker run -d --name irods -p 1247:1247 wtsi-npg/ub-16.04-irods-4.2.7:latest`
+`docker run -d --name irods -p 1247:1247 wtsi-npg/ub-18.04-irods-4.2.8:latest`
 
 ### Connecting
 The following iRODS users have been setup:


### PR DESCRIPTION
Add Ubuntu 18.04 base gosu image build
Add iRODS 4.2.8 Ubuntu 18.04 image build

Rename iRODS 4.2.7 image from 4.2 to 4.2.7 because even the minor
version is significant; the iRODS API has deprecations between the
minor versions, see https://github.com/wtsi-npg/baton/pull/224