### PR TITLE
Add baton 2.1.0 Singularity image built for iRODS 4.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,7 @@ builds where curl is later dropped.
 ### conda/ubuntu/12.04 ###
 
 A Conda package-building image with Conda, conda-build and
-conda-verify installed. Additional Dockerfiles exist for this image to
-allow variant to be made that support building iRODS 4.1 and iRODS 4.2.
-
-### irods/ubuntu/12.04 ###
-
-This is a Docker image of a vanilla iRODS 4.1.12 server that works out
-of the box. To be used for running tests only.
+conda-verify installed.
 
 ### irods/ubuntu/16.04 ###
 
@@ -38,12 +32,28 @@ of the box. To be used for running tests only.
 This is a Docker image of a vanilla iRODS 4.2.8 server that works out
 of the box. To be used for running tests only.
 
-## Build in instructions ##
+## Build instructions ##
 
 A makefile is supplied that will by default build all images and add
 metadata to them based on `git describe`.
 
-`cd containers`
+`cd ./docker`
+`make`
+
+# NPG Singularity images
+
+## The images
+
+### singularity/baton/baton-2.1.0 ###
+
+This is a Singularity image of baton 2.1.0 built for iRODS 4.2.7.
+
+## Build instructions ##
+
+A makefile is supplied that will by default build all images and add
+metadata to them based on `git describe`.
+
+`cd ./singularity`
 `make`
 
 ## Author

--- a/singularity/Makefile
+++ b/singularity/Makefile
@@ -1,0 +1,20 @@
+URL=$(patsubst %@,%,$(shell git ls-remote --get-url origin))
+TAG=$(shell git describe)
+
+SINGULARITY_ARGS ?=
+
+.PHONY: clean
+
+image_names := baton-2.1.0
+
+images := $(addsuffix .sif, $(image_names))
+
+all: $(images)
+
+baton-%.sif: baton/baton-%.def
+	SINGULARITYENV_GIT_URL=$(URL) \
+	SINGULARITYENV_GIT_REF=$(TAG) \
+	singularity build $(SINGULARITY_ARGS) $@ $<
+
+clean:
+	rm -f $(foreach image_name,$(image_names), $(image_name).sif)

--- a/singularity/baton/baton-2.1.0.def
+++ b/singularity/baton/baton-2.1.0.def
@@ -1,0 +1,124 @@
+BootStrap: library
+From: library://godloved/secure/ubuntu-xenial
+Fingerprints: B7761495F83E6BF7686CA5F0C1A7D02200787921
+Stage: build
+
+# Copy in some helper scripts
+%files
+  ./scripts/install_apt_tools.sh /install_apt_tools.sh
+  ./scripts/install_build_tools.sh /install_build_tools.sh
+  ./scripts/add_irods_apt_repository.sh /add_irods_apt_repository.sh
+  ./baton/baton-2.1.0.env /baton-2.1.0.env
+
+%post
+  . ${SINGULARITY_ROOTFS}/baton-2.1.0.env
+
+  apt-get update
+  apt-get install -q -y ca-certificates
+  ${SINGULARITY_ROOTFS}/install_apt_tools.sh
+  ${SINGULARITY_ROOTFS}/install_build_tools.sh
+  ${SINGULARITY_ROOTFS}/add_irods_apt_repository.sh
+
+  # Install baton build dependencies
+  apt-get install -q -y --no-install-recommends \
+    irods-runtime="$IRODS_VERSION" \
+    irods-dev="$IRODS_VERSION" \
+    libjansson-dev
+  apt-get install -q -y -f
+
+  # Fetch the baton release
+  cd ${SINGULARITY_ROOTFS}
+  curl -sS -L "$BATON_URL" -O
+  tar xfz baton-${BATON_VERSION}.tar.gz
+  mv baton-${BATON_VERSION} ${SINGULARITY_ROOTFS}/baton-src
+  cd ${SINGULARITY_ROOTFS}/baton-src
+
+  # Build baton
+  ./configure --prefix ${SINGULARITY_ROOTFS}/baton-build \
+            CPPFLAGS="-I/usr/include/irods" \
+            LDFLAGS="-L/usr/lib/irods/externals" || cat config.log
+  make install
+
+Bootstrap: library
+From: ubuntu:16.04
+Stage: install
+
+%help
+  baton iRODS client 2.1.0
+
+  For details of the supported iRODS version and the information
+  necessary to reproduce this image, please see the image metadata:
+
+    singularity inspect --labels <image path>
+
+  Documentation: https://wtsi-npg.github.io/baton/
+  Source:        https://github.com/wtsi-npg/baton
+
+# Copy in some helper scripts
+%files
+  ./scripts/install_apt_tools.sh /install_apt_tools.sh
+  ./scripts/uninstall_apt_tools.sh /uninstall_apt_tools.sh
+  ./scripts/add_irods_apt_repository.sh /add_irods_apt_repository.sh
+  ./baton/baton-2.1.0.env /baton-2.1.0.env
+
+# Copy the built baton tools from the build image
+%files from build  
+  baton-build/bin /usr/local/
+  baton-build/include /usr/local/
+  baton-build/lib /usr/local/
+
+%post
+  . ${SINGULARITY_ROOTFS}/baton-2.1.0.env 
+
+  apt-get update
+  apt-get install -q -y ca-certificates
+  ${SINGULARITY_ROOTFS}/install_apt_tools.sh
+  ${SINGULARITY_ROOTFS}/add_irods_apt_repository.sh
+
+  # Install baton runtime dependencies
+  apt-get install -q -y --no-install-recommends \
+    irods-runtime="$IRODS_VERSION" libjansson4
+  apt-get install -q -y -f
+
+  # Clean up
+  ${SINGULARITY_ROOTFS}/uninstall_apt_tools.sh
+  apt-get autoremove -q -y
+  apt-get clean -q -y
+  rm -rf /var/lib/apt/lists/*
+
+  # Annotate dynamic labels on the image
+  echo "org.label-schema.name baton-${BATON_VERSION}-irods-${IRODS_VERSION}" >> "$SINGULARITY_LABELS"
+  echo "org.label-schema.vcs-url $GIT_URL" >> "$SINGULARITY_LABELS"
+  echo "org.label-schema.vcs-ref $GIT_REF" >> "$SINGULARITY_LABELS"
+
+
+# Annotate static labels on the image
+%labels
+  Author Keith James
+  org.label-schema.vendor Wellcome Sanger Institute
+  org.label-schema.url https://wtsi-npg.github.io/baton/
+
+# Add all the baton tools as apps
+%apprun baton-chmod
+  exec baton-chmod "${@}"
+
+%apprun baton-get
+  exec baton-get "${@}"
+
+%apprun baton-list
+  exec baton-list "${@}"
+
+%apprun baton-metaquery
+  exec baton-metaquery "${@}"
+
+%apprun baton-put
+  exec baton-put "${@}"
+
+%apprun baton-specificquery
+  exec baton-specificquery "${@}"
+
+%apprun baton-do
+  exec baton-do "${@}"
+
+%test
+  baton-do --version

--- a/singularity/baton/baton-2.1.0.env
+++ b/singularity/baton/baton-2.1.0.env
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export IRODS_PACKAGES_URL="https://packages.irods.org"
+export UBUNTU_RELEASE="xenial"
+export IRODS_VERSION="4.2.7"
+
+export BATON_VERSION="2.1.0"
+export BATON_URL=https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz

--- a/singularity/scripts/add_irods_apt_repository.sh
+++ b/singularity/scripts/add_irods_apt_repository.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if ! curl -sSL $IRODS_PACKAGES_URL/irods-signing-key.asc | apt-key add -
+then
+    echo "Failed to fetch the iRODS package signing key"
+    exit 3
+fi
+
+if ! echo "deb [arch=amd64] $IRODS_PACKAGES_URL/apt $UBUNTU_RELEASE main" > \
+     /etc/apt/sources.list.d/renci-irods.list
+then
+    echo "Failed to add the iRODS apt repository"
+    exit 3
+fi    
+
+if ! apt-get update
+then
+    echo "apt-get update failed"
+    exit 3
+fi

--- a/singularity/scripts/install_apt_tools.sh
+++ b/singularity/scripts/install_apt_tools.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if ! apt-get install -q -y --no-install-recommends \
+     apt-transport-https \
+     curl \
+     gnupg-agent
+then
+    echo "Failed to install apt tools"
+    exit 3
+fi

--- a/singularity/scripts/install_build_tools.sh
+++ b/singularity/scripts/install_build_tools.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if ! apt-get install -q -y --no-install-recommends \
+     autoconf \
+     automake \
+     gcc \
+     g++ \
+     libtool-bin \
+     make
+then
+    echo "Failed to install build tools"
+    exit 3
+fi

--- a/singularity/scripts/uninstall_apt_tools.sh
+++ b/singularity/scripts/uninstall_apt_tools.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if ! apt-get remove -q -y \
+     apt-transport-https \
+     curl \
+     gnupg-agent
+then
+    echo "Failed to uninstall apt tools"
+    exit 3
+fi


### PR DESCRIPTION
Builds `baton` in a Singularity container. We are likely to need this given the difficulty of packaging iRODS clients with Conda.