### PR TITLE
Add an iRODS 4.2.9 server Docker container build to the Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ of the box. To be used for running tests only.
 
 ### irods/ubuntu/18.04 ###
 
-This is a Docker image of a vanilla iRODS 4.2.8 server that works out
-of the box. To be used for running tests only.
+This is a Docker image of a vanilla iRODS 4.2.8 / 4.2.9 server that
+works out of the box. To be used for running tests only.
+
+The server version may be chosen by passing the Docker build argument
+`--build-arg IRODS_VERSION=<version>` (default is 4.2.8).
 
 ## Build instructions ##
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,6 +14,7 @@ image_names := ub-16.04-base ub-18.04-base
 image_names += ub-16.04-conda
 image_names += ub-16.04-irods-4.2.7
 image_names += ub-18.04-irods-4.2.8
+image_names += ub-18.04-irods-4.2.9
 
 images := $(addsuffix .$(TAG), $(image_names))
 
@@ -57,6 +58,14 @@ ub-18.04-irods-4.2.8.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:latest \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:$(TAG) --file $< ./irods
+	touch $@
+
+ub-18.04-irods-4.2.9.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
+	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.9 \
+	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
+	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.9:latest \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.9:$(TAG) --file $< ./irods
 	touch $@
 
 clean:

--- a/docker/irods/scripts/configure_irods.sh
+++ b/docker/irods/scripts/configure_irods.sh
@@ -33,6 +33,11 @@ cd /var/lib/irods/.irods/
 echo $(jq -f /opt/docker/irods/config/irods_environment.delta \
           ./irods_environment.json) > ./irods_environment.json
 
+# iRODS 4.2.9 needs to started here. It's not required for 4.2.7 and
+# 4.2.8, which appear to be started during setup. We call restart
+# because trying to start a server fails if one is already running.
+sudo service irods restart
+
 # Fix up the demoResc to use localhost, to avoid the transient
 # hostname of the build container being captured in the IES database.
 sudo su irods -c "iadmin modresc demoResc host localhost"


### PR DESCRIPTION
One minor tweak was required to the iRODS configuration script (iRODS 4.2.9 doesn't automatically get started during the build process).