### PR TITLE
install git and curl using Conda

### DIFF
--- a/docker/conda/scripts/install_conda.sh
+++ b/docker/conda/scripts/install_conda.sh
@@ -42,7 +42,7 @@ conda config --set auto_update_conda False
 conda config --set ssl_verify True
 conda config --set show_channel_urls True
 
-conda install -y jinja2 networkx packaging pyaml setuptools
+conda install -y jinja2 networkx packaging pyaml setuptools git curl
 conda install -y "conda-build=$CONDA_BUILD_VERSION" conda-verify
 
 pip install rfc3987


### PR DESCRIPTION
avoids certificate problems if base OS certs are not upgraded
by using certs from Conda by using Conda installed tools