### PR TITLE
Patch core.re to set the default resource

### DIFF
--- a/docker/irods/scripts/configure_irods.sh
+++ b/docker/irods/scripts/configure_irods.sh
@@ -27,6 +27,21 @@ cd /etc/irods/
 echo $(jq -f /opt/docker/irods/config/server_config.delta \
           ./server_config.json) > ./server_config.json
 
+# Patch core.re to set the default resource because sometimes iRODS
+# ignores the default resource set in either client or server config.
+# This bug affects:
+#
+# 4.2.7 (confirmed)
+# 4.2.8 (maybe
+# 4.2.9 ?
+#
+# The bug is still open after the release of 4.2.9, see:
+# https://github.com/irods/irods/issues/4692
+#
+echo "Applying workaround for https://github.com/irods/irods/issues/4692 in iRODS >=4.2.7"
+sed -i 's/acSetRescSchemeForCreate\(.*\)demoResc/acSetRescSchemeForCreate\1testResc/' /etc/irods/core.re
+sed -i 's/acSetRescSchemeForRepl\(.*\)demoResc/acSetRescSchemeForRepl\1testResc/' /etc/irods/core.re
+
 # Patch the irods user environment to remove the transient hostname of
 # the build container
 cd /var/lib/irods/.irods/
@@ -70,7 +85,7 @@ sudo su irods -c "iadmin addchildtoresc replResc unixfs2"
 # Put version-specific hackery here
 case "$IRODS_VERSION" in
     4.2.7)
-        echo Applying workaround for https://github.com/irods/irods/issues/4672 in iRODS 4.2.7
+        echo "Applying workaround for https://github.com/irods/irods/issues/4672 in iRODS 4.2.7"
         cd /tmp
         for user in public rodsadmin
         do


### PR DESCRIPTION
Patch core.re to set the default resource to `testResc` because sometimes iRODS ignores the default resource set in either client or server config. The bug is still open after the release of iRODS 4.2.9, see: https://github.com/irods/irods/issues/4692

This bug affects:

 4.2.7 (confirmed)
 4.2.8 (not observed, fixed by accident?)
 4.2.9 ?

