### PR TITLE
Add iRODS 4.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ of the box. To be used for running tests only.
 
 ### irods/ubuntu/18.04 ###
 
-This is a Docker image of a vanilla iRODS 4.2.8 / 4.2.9 server that
-works out of the box. To be used for running tests only.
+This is a Docker image of a vanilla iRODS >=4.2.8 server that works
+out of the box. To be used for running tests only.
 
 The server version may be chosen by passing the Docker build argument
-`--build-arg IRODS_VERSION=<version>` (default is 4.2.8).
+`--build-arg IRODS_VERSION=<version>` (default is 4.2.10).
 
 ## Build instructions ##
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,9 +14,13 @@ image_names := ub-16.04-base ub-18.04-base
 image_names += ub-16.04-irods-4.2.7
 image_names += ub-18.04-irods-4.2.8
 image_names += ub-18.04-irods-4.2.9
+image_names += ub-18.04-irods-4.2.10
 
 image_names += centos-7-base
 image_names += centos-7-conda
+
+git_url=$(shell git remote get-url origin)
+git_commit=$(shell git log --pretty=format:'%H' -n 1)
 
 images := $(addsuffix .$(TAG), $(image_names))
 
@@ -24,58 +28,66 @@ all: $(images)
 
 centos-7-base.$(TAG): base/centos/7/Dockerfile
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/centos-7-base:latest \
 	--tag $(TAG_NAMESPACE)/centos-7-base:$(TAG) --file $< ./base
 	touch $@
 
 ub-16.04-base.$(TAG): base/ubuntu/16.04/Dockerfile
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-16.04-base:latest \
 	--tag $(TAG_NAMESPACE)/ub-16.04-base:$(TAG) --file $< ./base
 	touch $@
 
 ub-18.04-base.$(TAG): base/ubuntu/18.04/Dockerfile
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-18.04-base:latest \
 	--tag $(TAG_NAMESPACE)/ub-18.04-base:$(TAG) --file $< ./base
 	touch $@
 
 centos-7-conda.$(TAG): conda/centos/7/Dockerfile centos-7-base.$(TAG)
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/centos-7-conda:latest \
 	--tag $(TAG_NAMESPACE)/centos-7-conda:$(TAG) --file $< ./conda
 	touch $@
 
 ub-16.04-irods-4.2.7.$(TAG): irods/ubuntu/16.04/Dockerfile ub-16.04-base.$(TAG)
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2.7:latest \
 	--tag $(TAG_NAMESPACE)/ub-16.04-irods-4.2.7:$(TAG) --file $< ./irods
 	touch $@
 
 ub-18.04-irods-4.2.8.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	docker build $(DOCKER_ARGS) \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:latest \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:$(TAG) --file $< ./irods
 	touch $@
 
 ub-18.04-irods-4.2.9.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.9 \
-	--label $(LABEL_NAMESPACE).repository=$(shell git remote get-url origin) \
-	--label $(LABEL_NAMESPACE).commit=$(shell git log --pretty=format:'%H' -n 1) \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.9:latest \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.9:$(TAG) --file $< ./irods
+	touch $@
+
+ub-18.04-irods-4.2.10.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
+	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.10 \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.10:latest \
+	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.10:$(TAG) --file $< ./irods
 	touch $@
 
 clean:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -67,7 +67,7 @@ ub-16.04-irods-4.2.7.$(TAG): irods/ubuntu/16.04/Dockerfile ub-16.04-base.$(TAG)
 	touch $@
 
 ub-18.04-irods-4.2.8.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
-	docker build $(DOCKER_ARGS) \
+	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.8 \
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(TAG_NAMESPACE)/ub-18.04-irods-4.2.8:latest \

--- a/docker/irods/ubuntu/18.04/Dockerfile
+++ b/docker/irods/ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM wsinpg/ub-18.04-base:latest
 
-ARG IRODS_VERSION=4.2.8
+ARG IRODS_VERSION=4.2.10
 ARG IRODS_PACKAGES_URL=https://packages.irods.org
 ARG UBUNTU_RELEASE=bionic
 

--- a/docker/irods/ubuntu/18.04/README.md
+++ b/docker/irods/ubuntu/18.04/README.md
@@ -1,8 +1,8 @@
-# iRODS 4.2.8 Server
+# iRODS 4.2.x Server
 
 **Not for use in production!**
 
-This is a Docker image of a vanilla iRODS 4.2.8 server that works out
+This is a Docker image of a vanilla iRODS 4.2.x server that works out
 of the box. To be used for running tests only.
 
 The iRODS server starts with a single user 'irods' configured.
@@ -12,7 +12,9 @@ The iRODS server starts with a single user 'irods' configured.
 
 To run the container (with iCAT port binding to the host machine):
 
-`docker run -d --name irods -p 1247:1247 wtsi-npg/ub-18.04-irods-4.2.8:latest`
+`docker run -d --name irods -p 1247:1247 wtsi-npg/ub-18.04-irods-[VERSION]:latest`
+
+where [VERSION] is the required release e.g. 4.2.10
 
 ### Connecting
 The following iRODS users have been setup:


### PR DESCRIPTION
Add iRODS 4.2.10

Make 4.2.10 the default if no version is specified. This is because
it's the 4.2.x release with the fewest known bugs.