### PR TITLE
Prevent Conda from being updated when conda-build is installed

### DIFF
--- a/docker/conda/scripts/install_conda_build.sh
+++ b/docker/conda/scripts/install_conda_build.sh
@@ -10,6 +10,10 @@ CONDA_BUILD_VERSION=${CONDA_BUILD_VERSION:-"3.21.7"}
 source $CONDA_INSTALL_DIR/etc/profile.d/conda.sh
 conda activate
 
+conda config --set auto_update_conda False
+conda config --set ssl_verify True
+conda config --set show_channel_urls True
+
 conda install -y -n base "conda-build=$CONDA_BUILD_VERSION" conda-verify
 conda install -y -n base curl git patch
 


### PR DESCRIPTION
Prevent Conda from being updated in an uncontrolled manner to a newer
version, when conda-build is installed. Without this change, we do not
know which version of Conda gets installed when images are built.