### PR TITLE
Fix Github Actions build Makefile arguments

### DIFF
--- a/.github/workflows/push_container_image.yml
+++ b/.github/workflows/push_container_image.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Build and push
         run: |
             cd docker
-            make GITHUB_ACTOR=${{ github.actor }}
+            make GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} GITHUB_ACTOR=${{ github.actor }}
 
             docker image prune --force
             docker images
 
-            make push GITHUB_ACTIONS=${{ github.action }} GITHUB_ACTOR=${{ github.actor }}
+            make push GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} GITHUB_ACTOR=${{ github.actor }}


### PR DESCRIPTION
The GITHUB_ACTIONS argument was not passed to the Makefile during
building.

The GITHUB_ACTIONS argument was set incorrectly to the value of
github.action (although this makes no matyerial difference; the
variable must simply be set, its value is unimportant.