### PR TITLE
Add iRODS client build environment containers

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,6 +19,10 @@ image_names += ub-16.04-irods-4.2.7
 image_names += ub-18.04-irods-4.2.11
 image_names += ub-18.04-irods-4.3.0
 
+image_names += ub-18.04-irods-clients-dev-4.2.11
+image_names += ub-18.04-irods-clients-dev-4.3.0
+image_names += ub-20.04-irods-clients-dev-4.3.0
+
 image_names += md-bullseye-irods-clients-4.2.11
 
 image_names += centos-7-base
@@ -103,7 +107,7 @@ ub-16.04-irods-4.2.7.$(TAG): irods/ubuntu/16.04/Dockerfile ub-16.04-base.$(TAG)
 	touch $@
 
 ub-18.04-irods-4.2.11.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
-	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.11-1~bionic \
+	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.2.11 \
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-4.2.11:latest \
@@ -111,7 +115,7 @@ ub-18.04-irods-4.2.11.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	touch $@
 
 ub-18.04-irods-4.3.0.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
-	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.3.0-1~bionic \
+	docker build $(DOCKER_ARGS) --build-arg IRODS_VERSION=4.3.0 \
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-4.3.0:latest \
@@ -124,6 +128,36 @@ md-bullseye-irods-clients-4.2.11.$(TAG): irods_clients/minideb/bullseye/Dockerfi
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/md-bullseye-irods-clients-4.2.11:latest \
 	--tag $(DOCKER_TAG_PREFIX)/md-bullseye-irods-clients-4.2.11:$(TAG) --file $< ./irods_clients
+	touch $@
+
+ub-18.04-irods-clients-dev-4.2.11.$(TAG): irods_clients_dev/ubuntu/Dockerfile
+	docker build $(DOCKER_ARGS) \
+	--build-arg BASE_IMAGE=ubuntu:bionic \
+	--build-arg IRODS_VERSION=4.2.11 \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:latest \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:$(TAG) --file $< ./irods
+	touch $@
+
+ub-18.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
+	docker build $(DOCKER_ARGS) \
+	--build-arg BASE_IMAGE=ubuntu:bionic \
+	--build-arg IRODS_VERSION=4.3.0 \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:latest \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods
+	touch $@
+
+ub-20.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
+	docker build $(DOCKER_ARGS) \
+	--build-arg BASE_IMAGE=ubuntu:focal \
+	--build-arg IRODS_VERSION=4.3.0 \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
+	--tag $(DOCKER_TAG_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:latest \
+	--tag $(DOCKER_TAG_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods
 	touch $@
 
 %.$(TAG).pushed: %.$(TAG)

--- a/docker/irods/ubuntu/16.04/Dockerfile
+++ b/docker/irods/ubuntu/16.04/Dockerfile
@@ -1,10 +1,7 @@
 ARG DOCKER_TAG_PREFIX=wsinpg
-
 FROM $DOCKER_TAG_PREFIX/ub-16.04-base:latest
 
-ARG IRODS_VERSION=4.2.7
-ARG IRODS_PACKAGES_URL=https://packages.irods.org
-ARG UBUNTU_RELEASE=xenial
+ARG IRODS_VERSION="4.2.7"
 
 WORKDIR /opt/docker/irods
 
@@ -12,25 +9,39 @@ COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN apt-get update && \
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
+    apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
-    curl && \
-    curl -sSL $IRODS_PACKAGES_URL/irods-signing-key.asc | apt-key add - && \
-    echo "deb [arch=amd64] $IRODS_PACKAGES_URL/apt $UBUNTU_RELEASE main" | \
+    curl \
+    lsb-release \
+    jq \
+    netcat \
+    patch \
+    postgresql \
+    rsyslog \
+    unattended-upgrades \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \
     tee /etc/apt/sources.list.d/renci-irods.list && \
     apt-get update && \
     apt-get install -q -y --no-install-recommends \
-    postgresql \
-    jq \
-    patch \
     irods-server="$IRODS_VERSION" \
     irods-runtime="$IRODS_VERSION" \
     irods-database-plugin-postgres="$IRODS_VERSION" \
     irods-icommands="$IRODS_VERSION" \
     irods-dev="$IRODS_VERSION" && \
     apt-get install -q -y -f && \
+    unattended-upgrade -d -v && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \
     rm -rf /var/lib/apt/lists/*
@@ -39,6 +50,8 @@ RUN /opt/docker/irods/scripts/create_database.sh && \
     /opt/docker/irods/scripts/configure_irods.sh
 
 EXPOSE 1247
+
+HEALTHCHECK --interval=10s --timeout=30s --start-period=5s --retries=3 CMD [ "nc", "-v", "-z", "localhost", "1247" ]
 
 ENTRYPOINT []
 CMD ["/opt/docker/irods/scripts/start_irods.sh"]

--- a/docker/irods/ubuntu/18.04/Dockerfile
+++ b/docker/irods/ubuntu/18.04/Dockerfile
@@ -1,10 +1,7 @@
 ARG DOCKER_TAG_PREFIX=wsinpg
-
 FROM $DOCKER_TAG_PREFIX/ub-18.04-base:latest
 
-ARG IRODS_VERSION=4.3.0-1~bionic
-ARG IRODS_PACKAGES_URL=https://packages.irods.org
-ARG UBUNTU_RELEASE=bionic
+ARG IRODS_VERSION="4.3.0"
 
 WORKDIR /opt/docker/irods
 
@@ -12,28 +9,41 @@ COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN apt-get update && \
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
+    apt-get update && \
     apt-get install -q -y --no-install-recommends \
-    apt-transport-https \
+    apt-utils \
     ca-certificates \
+    curl \
     gpg \
     gpg-agent \
-    curl && \
-    curl -sSL $IRODS_PACKAGES_URL/irods-signing-key.asc | apt-key add - && \
-    echo "deb [arch=amd64] $IRODS_PACKAGES_URL/apt $UBUNTU_RELEASE main" | \
+    lsb-release \
+    jq \
+    netcat \
+    patch \
+    postgresql \
+    rsyslog \
+    unattended-upgrades \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \
     tee /etc/apt/sources.list.d/renci-irods.list && \
     apt-get update && \
     apt-get install -q -y --no-install-recommends \
-    postgresql \
-    jq \
-    patch \
-    rsyslog \
-    irods-server="$IRODS_VERSION" \
-    irods-runtime="$IRODS_VERSION" \
-    irods-database-plugin-postgres="$IRODS_VERSION" \
-    irods-icommands="$IRODS_VERSION" \
-    irods-dev="$IRODS_VERSION" && \
+    irods-server="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-runtime="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-database-plugin-postgres="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-dev="${IRODS_VERSION}-1~$(lsb_release -sc)" && \
     apt-get install -q -y -f && \
+    unattended-upgrade -d -v && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \
     rm -rf /var/lib/apt/lists/*
@@ -42,6 +52,8 @@ RUN /opt/docker/irods/scripts/create_database.sh && \
     /opt/docker/irods/scripts/configure_irods.sh
 
 EXPOSE 1247
+
+HEALTHCHECK --interval=10s --timeout=30s --start-period=5s --retries=3 CMD [ "nc", "-v", "-z", "localhost", "1247" ]
 
 ENTRYPOINT []
 CMD ["/opt/docker/irods/scripts/start_irods.sh"]

--- a/docker/irods/ubuntu/18.04/README.md
+++ b/docker/irods/ubuntu/18.04/README.md
@@ -1,4 +1,4 @@
-# iRODS 4.2.x Server
+# iRODS 4.3.x Server
 
 **Not for use in production!**
 

--- a/docker/irods_clients_dev/ubuntu/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/Dockerfile
@@ -1,0 +1,64 @@
+ARG BASE_IMAGE=ubuntu:bionic
+FROM $BASE_IMAGE
+
+# Other versions available on bionic are 4.3.0
+ARG IRODS_VERSION="4.2.11"
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    dirmngr \
+    gpg \
+    gpg-agent \
+    lsb-release \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    irods-dev="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-runtime="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)"
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "E1DD270288B4E6030699E45FA1715D88E1DF1F24" && \
+    echo "deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/git-core.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    git
+
+RUN apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    check \
+    gdb \
+    jq \
+    lcov \
+    less \
+    libjansson-dev \
+    libtool \
+    netcat \
+    pkg-config \
+    python3-sphinx \
+    ssh \
+    valgrind \
+    unattended-upgrades && \
+    unattended-upgrade -d -v
+
+ENV CPPFLAGS="-I/usr/include/irods" \
+    CK_DEFAULT_TIMEOUT=20
+
+CMD ["/bin/bash"]

--- a/docker/irods_clients_dev/ubuntu/README.md
+++ b/docker/irods_clients_dev/ubuntu/README.md
@@ -1,0 +1,23 @@
+# Ubuntu iRODS client development
+
+## Summary
+
+An image aimed at development of command line iRODS clients.
+
+ - C development tools, including GCC, GDB, autoconf, automake, libtool
+   pkg-config and valgrind.
+ - [iRODS runtime and development packages](https://github.com/irods/irods)
+ - [iRODS icommands](https://github.com/irods/irods_client_icommands)
+ - [Dependencies required by baton](https://github.com/wtsi-npg/baton)
+ 
+This image is intended for use anywhere that iRODS C clients are built.
+
+## Usage
+
+This image will create a development container suitable for
+[baton](https://github.com/wtsi-npg/baton) and other iRODS clients.
+
+The Dockerfile supports two build arguments:
+
+- BASE_IMAGE (defaults to "ubuntu:bionic")
+- IRODS_VERSION (defaults to "4.2.11")


### PR DESCRIPTION
Add a Dockerfile for iRODS client building
  - Use standard iRODS version number as a parameter
  - Add builds for this to the Makefile for
    - iRODS clients 4.2.11 on Ubuntu 18.04
    - iRODS clients 4.3.0 on Ubuntu 18.04 - iRODS clients 4.3.0 on Ubuntu 20.04

Improve Ubuntu the 18.04 iRODS server Dockerfile
  - Use standard iRODS version number as a parameter e.g. 4.3.0 rather than the package version e.g. 4.3.0-1~bionic
  - Add unattended-upgrade build step
  - Set an en_GB locale