### PR TITLE
Add Ubuntu-hosted iRODS clients without using Conda

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,6 +23,8 @@ image_names += ub-18.04-irods-clients-dev-4.2.11
 image_names += ub-18.04-irods-clients-dev-4.3.0
 image_names += ub-20.04-irods-clients-dev-4.3.0
 
+image_names += ub-18.04-irods-clients-4.2.11
+
 image_names += md-bullseye-irods-clients-4.2.11
 
 image_names += centos-7-base
@@ -130,6 +132,19 @@ md-bullseye-irods-clients-4.2.11.$(TAG): irods_clients/minideb/bullseye/Dockerfi
 	--tag $(DOCKER_TAG_PREFIX)/md-bullseye-irods-clients-4.2.11:$(TAG) --file $< ./irods_clients
 	touch $@
 
+ub-18.04-irods-clients-4.2.11.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-base.$(TAG)
+	docker build $(DOCKER_ARGS) \
+	--build-arg BASE_IMAGE=wsinpg/ub-18.04-base \
+	--build-arg IRODS_VERSION=4.2.11 \
+	--build-arg BATON_VERSION=4.0.0 \
+	--build-arg HTSLIB_VERSION=1.16 \
+	--build-arg SAMTOOLS_VERSION=1.16.1 \
+	--label $(LABEL_NAMESPACE).repository=$(git_url) \
+	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-4.2.11:latest \
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-4.2.11:$(TAG) --file $< ./irods_clients
+	touch $@
+
 ub-18.04-irods-clients-dev-4.2.11.$(TAG): irods_clients_dev/ubuntu/Dockerfile
 	docker build $(DOCKER_ARGS) \
 	--build-arg BASE_IMAGE=ubuntu:bionic \
@@ -137,7 +152,7 @@ ub-18.04-irods-clients-dev-4.2.11.$(TAG): irods_clients_dev/ubuntu/Dockerfile
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:latest \
-	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:$(TAG) --file $< ./irods
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
 ub-18.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
@@ -147,7 +162,7 @@ ub-18.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:latest \
-	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods
+	--tag $(DOCKER_TAG_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
 ub-20.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
@@ -157,7 +172,7 @@ ub-20.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
 	--label $(LABEL_NAMESPACE).repository=$(git_url) \
 	--label $(LABEL_NAMESPACE).commit=$(git_commit) \
 	--tag $(DOCKER_TAG_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:latest \
-	--tag $(DOCKER_TAG_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods
+	--tag $(DOCKER_TAG_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
 %.$(TAG).pushed: %.$(TAG)

--- a/docker/conda/minideb/bullseye/Dockerfile
+++ b/docker/conda/minideb/bullseye/Dockerfile
@@ -57,7 +57,7 @@ ENV LANG=en_GB.UTF-8 \
     rsync \
     vim \
     unattended-upgrades && \
-    unattended-upgrade -d -v && \
+    unattended-upgrade -v && \
     apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \

--- a/docker/irods/ubuntu/16.04/Dockerfile
+++ b/docker/irods/ubuntu/16.04/Dockerfile
@@ -41,7 +41,8 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
     irods-icommands="$IRODS_VERSION" \
     irods-dev="$IRODS_VERSION" && \
     apt-get install -q -y -f && \
-    unattended-upgrade -d -v && \
+    unattended-upgrade -v && \
+    apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/irods/ubuntu/18.04/Dockerfile
+++ b/docker/irods/ubuntu/18.04/Dockerfile
@@ -43,7 +43,8 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
     irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)" \
     irods-dev="${IRODS_VERSION}-1~$(lsb_release -sc)" && \
     apt-get install -q -y -f && \
-    unattended-upgrade -d -v && \
+    unattended-upgrade -v && \
+    apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/irods_clients/minideb/bullseye/Dockerfile
+++ b/docker/irods_clients/minideb/bullseye/Dockerfile
@@ -25,7 +25,7 @@ ENV LANG=en_GB.UTF-8 \
 
 RUN apt-get install -q -y --no-install-recommends \
     unattended-upgrades && \
-    unattended-upgrade -d -v && \
+    unattended-upgrade -v && \
     apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \
     apt-get clean && \

--- a/docker/irods_clients/scripts/start_client_container.sh
+++ b/docker/irods_clients/scripts/start_client_container.sh
@@ -11,7 +11,7 @@ IRODS_VERSION=${IRODS_VERSION:-"4.2.11"}
 IRODS_ENVIRONMENT_FILE=${IRODS_ENVIRONMENT_FILE:-"$HOME/.irods/irods_environment.json"}
 
 DOCKER_TAG=${DOCKER_TAG:-latest}
-DOCKER_IMAGE=${DOCKER_IMAGE:-"wsinpg/md-bullseye-irods-clients-${IRODS_VERSION}:${DOCKER_TAG}"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"wsinpg/ub-18.04-irods-clients-${IRODS_VERSION}:${DOCKER_TAG}"}
 
 # The default container name matches that used by the irods_client_wrapper.sh
 # script

--- a/docker/irods_clients/ubuntu/Dockerfile
+++ b/docker/irods_clients/ubuntu/Dockerfile
@@ -137,7 +137,7 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
     liblzma5 \
     zlib1g \
     unattended-upgrades && \
-    unattended-upgrade -d -v && \
+    unattended-upgrade -v && \
     apt-get remove -q -y unattended-upgrades && \
     apt-get autoremove -q -y && \
     apt-get clean -q -y && \

--- a/docker/irods_clients/ubuntu/Dockerfile
+++ b/docker/irods_clients/ubuntu/Dockerfile
@@ -1,0 +1,153 @@
+ARG BASE_IMAGE=ubuntu:bionic
+FROM $BASE_IMAGE as installer
+
+# Other iRODS versions available on bionic are 4.3.0
+ARG IRODS_VERSION="4.2.11"
+ARG BATON_VERSION="4.0.0"
+ARG HTSLIB_VERSION="1.16"
+ARG SAMTOOLS_VERSION="1.16.1"
+ARG HTSLIB_PLUGINS_VERSION="201712"
+
+COPY . /opt/docker/irods_clients
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    dirmngr \
+    gpg \
+    gpg-agent \
+    lsb-release \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    irods-dev="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-runtime="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)"
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "E1DD270288B4E6030699E45FA1715D88E1DF1F24" && \
+    echo "deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/git-core.list && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    git
+
+# libdeflate-dev is not available on Ubuntu 18.04
+RUN apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    less \
+    libtool \
+    pkg-config \
+    python3-sphinx \
+    ssh \
+    libjansson-dev \
+    libbz2-dev \
+    libcurl3-dev \
+    liblzma-dev \
+    zlib1g-dev
+
+ENV CPPFLAGS="-I/usr/include/irods"
+
+RUN cd /tmp && \
+    curl -sSL -O "https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz" && \
+    tar xfz baton-${BATON_VERSION}.tar.gz && \
+    cd baton-${BATON_VERSION} && \
+    ./configure && \
+    make install && \
+    cd /tmp && \
+    rm -rf /tmp/baton-${BATON_VERSION}*
+
+RUN cd /tmp && \
+    curl -sSL -O "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" && \
+    tar xfj htslib-${HTSLIB_VERSION}.tar.bz2 && \
+    cd htslib-${HTSLIB_VERSION} && \
+    ./configure --enable-plugins --without-curses && \
+    make install && \
+    ldconfig && \
+    cd /tmp && \
+    rm -rf /tmp/htslib-${HTSLIB_VERSION}*
+
+RUN cd /tmp && \
+    curl -sSL -O "https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2" && \
+    tar xfj samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
+    cd samtools-${SAMTOOLS_VERSION} && \
+    ./configure --with-htslib=system --without-curses && \
+    make install && \
+    cd /tmp && \
+    rm -rf /tmp/samtools-${SAMTOOLS_VERSION}*
+
+RUN cd /tmp && \
+    git clone --depth 1 --branch ${HTSLIB_PLUGINS_VERSION} "https://github.com/samtools/htslib-plugins.git" && \
+    cd htslib-plugins && \
+    make install && \
+    cd /tmp && \
+    rm -rf htslib-plugins*
+
+FROM $BASE_IMAGE 
+
+ARG IRODS_VERSION="4.2.11"
+ARG BATON_VERSION="4.0.0"
+ARG HTSLIB_VERSION="1.16"
+ARG SAMTOOLS_VERSION="1.16.1"
+ARG HTSLIB_PLUGINS_VERSION="201712"
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    dirmngr \
+    gpg \
+    gpg-agent \
+    lsb-release \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update && \ 
+    apt-get install -q -y --no-install-recommends \
+    irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    irods-runtime="${IRODS_VERSION}-1~$(lsb_release -sc)" \
+    libjansson4 \
+    libbz2-1.0 \    
+    libcurl3 \
+    liblzma5 \
+    zlib1g \
+    unattended-upgrades && \
+    unattended-upgrade -d -v && \
+    apt-get remove -q -y unattended-upgrades && \
+    apt-get autoremove -q -y && \
+    apt-get clean -q -y && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer /usr/local /usr/local
+COPY --from=installer /opt/docker/irods_clients/scripts/* /opt/docker/irods_clients/scripts/
+
+RUN ldconfig
+
+ENTRYPOINT ["/opt/docker/irods_clients/scripts/docker-entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/irods_clients/ubuntu/README.md
+++ b/docker/irods_clients/ubuntu/README.md
@@ -1,0 +1,38 @@
+# Ubuntu iRODS clients
+
+## Summary
+
+An image with iRODS clients installed.
+
+ - [iRODS icommands](https://github.com/irods/irods_client_icommands)
+ - [baton](https://github.com/wtsi-npg/baton)
+ - [samtools](https://github.com/samtools/samtools), with the htslib [iRODS plugin](https://github.com/samtools/htslib-plugins)
+
+This image is intended for use anywhere that container clients are
+required. It uses clients supplied by RENCI as Debian packages, or built
+from source where packages are not available.
+
+## Usage
+
+The recommended way to use these clients as a direct replacement for
+e.g. the icommands (`ils`, `iget` etc), is via the wrapper script
+`irods_client_wrapper.sh` in `irods_clients/scripts`, which relies on
+having a container already running. The script should be symlinked,
+once for each desired client, to the desired client name:
+
+E.g.
+
+    ln -s irods_client_wrapper.sh ./bin/ils
+    ln -s irods_client_wrapper.sh ./bin/iget
+    ln -s irods_client_wrapper.sh ./bin/imeta
+
+Executing the script through each of these symlinks will invoke the
+respective client within the container.
+
+The `irods_clients/scripts` directory contains an example container
+startup script, `start_client_container.sh`. It is intended only as an
+example of how to start the container because it mounts the entire
+user `$HOME` into it, which is not recommended for security and
+performance reasons. Instead, it is prefereable to bring up the
+container as part of a Docker Compose configuration, with directory
+mounts of a more limited scope.

--- a/docker/irods_clients_dev/ubuntu/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
     ssh \
     valgrind \
     unattended-upgrades && \
-    unattended-upgrade -d -v
+    unattended-upgrade -v
 
 ENV CPPFLAGS="-I/usr/include/irods" \
     CK_DEFAULT_TIMEOUT=20


### PR DESCRIPTION
Add a Dockerfile supporting at least Ubuntu 18.04 and 20.04.

Update the client container startup script to use the new image by
default.

Update the Makefile to build iRODS 4.2.11 clients on Ubuntu 18.04.

Built on #44 which should be merged first