### PR TITLE
Add iRODS 4-3-stable server nightly build

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,11 +14,13 @@ DOCKER_ARGS ?= --platform linux/amd64 --progress=plain --rm
 
 .PHONY: clean push
 
-image_names := ub-16.04-base ub-18.04-base
+image_names := ub-16.04-base ub-18.04-base ub-22.04-base
 image_names += ub-16.04-irods-4.2.7
 image_names += ub-18.04-irods-4.2.11
 image_names += ub-18.04-irods-4.2.12
 image_names += ub-18.04-irods-4.3.0
+
+image_names += ub-22.04-irods-4.3-nightly
 
 image_names += ub-18.04-irods-clients-dev-4.2.11
 image_names += ub-18.04-irods-clients-dev-4.2.12
@@ -79,6 +81,18 @@ ub-18.04-base.$(TAG): base/ubuntu/18.04/Dockerfile
 	--label org.opencontainers.image.created=$(NOW) \
 	--tag $(DOCKER_PREFIX)/ub-18.04-base:latest \
 	--tag $(DOCKER_PREFIX)/ub-18.04-base:$(TAG) --file $< ./base
+	touch $@
+
+ub-22.04-base.$(TAG): base/ubuntu/22.04/Dockerfile
+	docker build $(DOCKER_ARGS) \
+	--build-arg DOCKER_PREFIX=$(DOCKER_PREFIX) \
+	--label org.opencontainers.image.title="Base image, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-base:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-base:$(TAG) --file $< ./base
 	touch $@
 
 md-bullseye-base.$(TAG): base/minideb/bullseye/Dockerfile
@@ -178,6 +192,19 @@ ub-18.04-irods-4.3.0.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	--label org.opencontainers.image.created=$(NOW) \
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-4.3.0:latest \
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-4.3.0:$(TAG) --file $< ./irods
+	touch $@
+
+ub-22.04-irods-4.3-nightly.$(TAG): irods/ubuntu/22.04/Dockerfile ub-22.04-base.$(TAG)
+	docker build $(DOCKER_ARGS) \
+	--build-arg DOCKER_PREFIX=$(DOCKER_PREFIX) \
+	--build-arg IRODS_VERSION=4.3-nightly \
+	--label org.opencontainers.image.title="iRODS 4.3-nightly server, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-4.3-nightly:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-4.3-nightly:$(TAG) --file $< ./irods
 	touch $@
 
 ub-18.04-irods-clients-4.2.11.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-base.$(TAG)

--- a/docker/base/ubuntu/22.04/Dockerfile
+++ b/docker/base/ubuntu/22.04/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04 as installer
+
+ENV GOSU_VERSION=1.16
+
+COPY ./scripts /opt/docker/base/scripts
+
+RUN apt-get update && \
+    apt-get install -q -y \
+    apt-utils \
+    bzip2 \
+    ca-certificates \
+    curl \
+    gpg \
+    unattended-upgrades && \
+    unattended-upgrade -d -v
+
+RUN GOSU_VERSION=$GOSU_VERSION /opt/docker/base/scripts/install_gosu.sh && \
+    chmod +x /opt/docker/base/scripts/docker-entrypoint.sh
+
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -q -y \
+    apt-utils \
+    unattended-upgrades && \
+    unattended-upgrade -d -v && \
+    apt-get remove -q -y unattended-upgrades && \
+    apt-get autoremove -q -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=installer /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=installer /opt/docker/base/scripts/docker-entrypoint.sh \
+    /opt/docker/base/scripts/docker-entrypoint.sh
+
+ENTRYPOINT ["/opt/docker/base/scripts/docker-entrypoint.sh"]

--- a/docker/base/ubuntu/22.04/README.md
+++ b/docker/base/ubuntu/22.04/README.md
@@ -1,0 +1,1 @@
+A base image with gosu installed.

--- a/docker/irods/scripts/configure_irods.sh
+++ b/docker/irods/scripts/configure_irods.sh
@@ -9,10 +9,12 @@ service postgresql start
 # Run the iRODS setup script which configures the new server.
 
 case "$IRODS_VERSION" in
+   4.3-nightly)
+        python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
+        ;;
     4.1.*)
         /var/lib/irods/packaging/setup_irods.sh < /opt/docker/irods/config/setup_irods.sh.in
         ;;
-
     4.2.*)
         patch /var/lib/irods/scripts/irods/lib.py /opt/docker/irods/patches/patch_lib.diff
         python /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/setup_irods.py.in

--- a/docker/irods/ubuntu/22.04/Dockerfile
+++ b/docker/irods/ubuntu/22.04/Dockerfile
@@ -1,0 +1,60 @@
+ARG DOCKER_TAG_PREFIX=wsinpg
+FROM $DOCKER_TAG_PREFIX/ub-22.04-base:latest
+
+ARG IRODS_VERSION="nightly"
+
+WORKDIR /opt/docker/irods
+
+COPY ./scripts/*.sh ./scripts/
+COPY ./config/* ./config/
+COPY ./patches/* ./patches/
+
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    gpg \
+    gpg-agent \
+    lsb-release \
+    jq \
+    netcat \
+    patch \
+    postgresql \
+    rsyslog \
+    unattended-upgrades \
+    locales && \
+    locale-gen en_GB en_GB.UTF-8 && \
+    localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8
+
+# Required to get the externals packages
+RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \
+    tee /etc/apt/sources.list.d/renci-irods.list && \
+    apt-get update
+
+ENV NIGHTLY_URL_BASE=https://github.com/wtsi-npg/irods_development_environment/releases/download/nightly/
+
+RUN curl -sSL \
+    -O ${NIGHTLY_URL_BASE}irods-database-plugin-postgres_4.3.0-1.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.0-1.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.0-1.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-server_4.3.0-1.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.0-1.jammy_amd64.deb
+
+RUN ls -l && apt-get install -y ./*.deb
+
+RUN /opt/docker/irods/scripts/create_database.sh && \
+    /opt/docker/irods/scripts/configure_irods.sh
+
+EXPOSE 1247
+
+HEALTHCHECK --interval=10s --timeout=30s --start-period=5s --retries=3 CMD [ "nc", "-v", "-z", "localhost", "1247" ]
+
+ENTRYPOINT []
+CMD ["/opt/docker/irods/scripts/start_irods.sh"]

--- a/docker/irods/ubuntu/22.04/README.md
+++ b/docker/irods/ubuntu/22.04/README.md
@@ -1,0 +1,106 @@
+# iRODS 4.3.x Server
+
+**Not for use in production!**
+
+This is a Docker image of a vanilla iRODS 4.3.x server that works out
+of the box. To be used for running tests only.
+
+The iRODS server starts with a single user 'irods' configured.
+
+## Using the container
+### Running
+
+To run the container (with iCAT port binding to the host machine):
+
+`docker run -d --name irods -p 1247:1247 wtsi-npg/ub-18.04-irods-[VERSION]:latest`
+
+where [VERSION] is the required release e.g. 4.3.0
+
+### Connecting
+The following iRODS users have been setup:
+
+    | Username | Password | Zone     | Admin |
+    | -------- | -------- | -------- | ----- |
+    | irods    | irods    | testZone | Yes   |
+
+
+The `irods_environment.json` in `~/.irods` required to connect as the
+preconfigured 'irods' user is:
+
+    {
+     "irods_host": "localhost",
+     "irods_port": 1247,
+     "irods_user_name": "irods",
+     "irods_zone_name": "testZone",
+     "irods_plugins_home": <path to iRODS plugins>,
+     "irods_default_resource": <resource name>
+    }
+
+Two resources are configured; a simple resource named "testResc" and a
+replication resource named "replResc" where each data object will be
+replicated to two filesystem vaults:
+
+    resource name: testResc
+    id: 10018
+    zone: testZone
+    type: replication
+    class: cache
+    location: EMPTY_RESC_HOST
+    vault: EMPTY_RESC_PATH
+    free space: 
+    free space time: : Never
+    status: 
+    info: 
+    comment: 
+    create time: 01559922677: 2019-06-07.16:51:17
+    modify time: 01559922677: 2019-06-07.16:51:17
+    children: 
+    context: 
+    parent: 
+    object count: 
+    ----
+    resource name: unixfs2
+    id: 10017
+    zone: testZone
+    type: unixfilesystem
+    class: cache
+    location: localhost
+    vault: /var/lib/irods/iRODS/Vault2
+    free space: 
+    free space time: : Never
+    status: 
+    info: 
+    comment: 
+    create time: 01559922677: 2019-06-07.16:51:17
+    modify time: 01559922678: 2019-06-07.16:51:18
+    children: 
+    context: 
+    parent: 10018
+    object count: 
+    ----
+    resource name: unixfs1
+    id: 10016
+    zone: testZone
+    type: unixfilesystem
+    class: cache
+    location: localhost
+    vault: /var/lib/irods/iRODS/Vault
+    free space: 
+    free space time: : Never
+    status: 
+    info: 
+    comment: 
+    create time: 01559922677: 2019-06-07.16:51:17
+    modify time: 01559922678: 2019-06-07.16:51:18
+    children: 
+    context: 
+    parent: 10018
+    object count:
+
+
+
+## Acknowledgments
+
+This image was influenced by [that created by Colin
+Nolan](https://github.com/wtsi-hgi/docker-icat) and also by [WSI
+Disposable iRODS](https://github.com/wtsi-npg/disposable-irods)


### PR DESCRIPTION
Adds a server container using iRODS Debian packages build nightly from 4-3-stable.

~~Currently a draft because the packages URL in the Dockerfile is pointing to @kjsanger 's fork of the package-building repo, at the moment.~~