### PR TITLE
Update to baton 4.2.0

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -149,7 +149,7 @@ ub-16.04-irods-clients-4.2.7.$(TAG): irods_clients/ubuntu/16.04/Dockerfile ub-16
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.2.7 \
-	--build-arg BATON_VERSION=4.1.0 \
+	--build-arg BATON_VERSION=4.2.0 \
 	--build-arg HTSLIB_VERSION=1.18 \
 	--build-arg SAMTOOLS_VERSION=1.18 \
 	--build-arg BCFTOOLS_VERSION=1.18 \
@@ -170,7 +170,7 @@ ub-18.04-irods-clients-4.2.11.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-b
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.2.11 \
-	--build-arg BATON_VERSION=4.1.0 \
+	--build-arg BATON_VERSION=4.2.0 \
 	--build-arg HTSLIB_VERSION=1.18 \
 	--build-arg SAMTOOLS_VERSION=1.18 \
 	--build-arg BCFTOOLS_VERSION=1.18 \
@@ -183,23 +183,6 @@ ub-18.04-irods-clients-4.2.11.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-b
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-4.2.11:$(TAG) --file $< ./irods_clients
 	touch $@
 
-ub-18.04-irods-clients-dev-4.2.11.$(TAG): irods_clients_dev/ubuntu/Dockerfile
-	docker buildx build $(DOCKER_ARGS) \
-	--load \
-	--build-context singularity=../singularity \
-	--build-arg BASE_IMAGE=ubuntu:bionic \
-	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
-	--build-arg DOCKER_TAG=$(TAG) \
-	--build-arg IRODS_VERSION=4.2.11 \
-	--label org.opencontainers.image.title="iRODS 4.2.11 client development, Ubuntu 18.04" \
-	--label org.opencontainers.image.source=$(git_url) \
-	--label org.opencontainers.image.revision=$(git_commit) \
-	--label org.opencontainers.image.version=$(TAG) \
-	--label org.opencontainers.image.created=$(NOW) \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:latest \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-dev-4.2.11:$(TAG) --file $< ./irods_clients_dev
-	touch $@
-
 ub-18.04-irods-clients-4.2.12.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-base.$(TAG)
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
@@ -209,7 +192,7 @@ ub-18.04-irods-clients-4.2.12.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-b
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.2.12 \
-	--build-arg BATON_VERSION=4.1.0 \
+	--build-arg BATON_VERSION=4.2.0 \
 	--build-arg HTSLIB_VERSION=1.18 \
 	--build-arg SAMTOOLS_VERSION=1.18 \
 	--build-arg BCFTOOLS_VERSION=1.18 \
@@ -220,6 +203,28 @@ ub-18.04-irods-clients-4.2.12.$(TAG): irods_clients/ubuntu/Dockerfile ub-18.04-b
 	--label org.opencontainers.image.created=$(NOW) \
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-4.2.12:latest \
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-4.2.12:$(TAG) --file $< ./irods_clients
+	touch $@
+
+ub-22.04-irods-clients-4.3-nightly.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
+	docker buildx build $(DOCKER_ARGS) \
+	--load \
+	--build-context singularity=../singularity \
+	--build-arg DOCKER_PREFIX=$(DOCKER_PREFIX) \
+	--build-arg BASE_IMAGE=$(DOCKER_PREFIX)/ub-22.04-base \
+	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
+	--build-arg DOCKER_TAG=$(TAG) \
+	--build-arg IRODS_VERSION=4.3-nightly \
+	--build-arg BATON_VERSION=4.2.0 \
+	--build-arg HTSLIB_VERSION=1.18 \
+	--build-arg SAMTOOLS_VERSION=1.18 \
+	--build-arg BCFTOOLS_VERSION=1.18 \
+	--label org.opencontainers.image.title="iRODS 4.3-nightly clients, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-4.3-nightly:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-4.3-nightly:$(TAG) --file $< ./irods_clients
 	touch $@
 
 ub-16.04-irods-clients-dev-4.2.7.$(TAG): irods_clients_dev/ubuntu/16.04/Dockerfile
@@ -308,7 +313,7 @@ ub-20.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/Dockerfile
 	--tag $(DOCKER_PREFIX)/ub-20.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
-ub-20.04-irods-clients-dev-4.3-nightly.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfile
+ub-22.04-irods-clients-dev-4.3-nightly.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfile
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
 	--build-context singularity=../singularity \
@@ -317,7 +322,7 @@ ub-20.04-irods-clients-dev-4.3-nightly.$(TAG): irods_clients_dev/ubuntu/22.04/Do
 	--build-arg IRODS_VERSION=4.3-nightly \
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
-	--label org.opencontainers.image.title="iRODS 4.3.0 client development, Ubuntu 20.04" \
+	--label org.opencontainers.image.title="iRODS 4.3-nightly client development, Ubuntu 22.04" \
 	--label org.opencontainers.image.source=$(git_url) \
 	--label org.opencontainers.image.revision=$(git_commit) \
 	--label org.opencontainers.image.version=$(TAG) \
@@ -325,7 +330,6 @@ ub-20.04-irods-clients-dev-4.3-nightly.$(TAG): irods_clients_dev/ubuntu/22.04/Do
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3-nightly:latest \
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3-nightly:$(TAG) --file $< ./irods_clients_dev
 	touch $@
-
 
 %.$(TAG).pushed: %.$(TAG)
 	docker push $(DOCKER_PREFIX)/$*:$(TAG)

--- a/docker/irods_clients/ubuntu/16.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/16.04/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=ubuntu:16.04
 FROM $BASE_IMAGE as installer
 
 ARG IRODS_VERSION="4.2.7"
-ARG BATON_VERSION="4.1.0"
+ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"
 ARG BCFTOOLS_VERSION="1.18"
@@ -53,14 +53,12 @@ RUN apt-get update && \
     autoconf \
     automake \
     build-essential \
-    less \
     libtool \
     pkg-config \
     python3-sphinx \
-    ssh \
-    libjansson-dev \
     libbz2-dev \
     libcurl3-dev \
+    libjansson-dev \
     liblzma-dev \
     zlib1g-dev
 
@@ -134,13 +132,11 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
     irods-icommands="${IRODS_VERSION}"
 
 RUN apt-get install -q -y --no-install-recommends \
-    gnuplot \
     jq \
-    libjansson4 \
     libbz2-1.0 \
     libcurl3 \
+    libjansson4 \
     liblzma5 \
-    perl \
     zlib1g \
     unattended-upgrades && \
     unattended-upgrade -v && \

--- a/docker/irods_clients/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/22.04/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE as installer
 
 ARG IRODS_VERSION="4.3-nightly"
-ARG BATON_VERSION="4.1.0"
+ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"
 ARG BCFTOOLS_VERSION="1.18"
@@ -49,15 +49,14 @@ RUN apt-get update && \
     autoconf \
     automake \
     build-essential \
-    less \
+    git \
     libtool \
     pkg-config \
     python3-sphinx \
-    ssh \
-    libdeflate-dev \
-    libjansson-dev \
     libbz2-dev \
     libcurl3-dev \
+    libdeflate-dev \
+    libjansson-dev \
     liblzma-dev \
     zlib1g-dev
 
@@ -135,14 +134,12 @@ RUN curl -sSL \
 RUN ls -l && apt-get install -y ./*.deb
 
 RUN apt-get install -q -y --no-install-recommends \
-    gnuplot \
     jq \
-    libdeflate0 \
-    libjansson4 \
     libbz2-1.0 \
     libcurl4 \
+    libdeflate0 \
+    libjansson4 \
     liblzma5 \
-    perl \
     zlib1g \
     unattended-upgrades && \
     unattended-upgrade -v && \

--- a/docker/irods_clients/ubuntu/Dockerfile
+++ b/docker/irods_clients/ubuntu/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_IMAGE as installer
 
 # Other iRODS versions available on bionic are 4.3.0
 ARG IRODS_VERSION="4.2.11"
-ARG BATON_VERSION="4.1.0"
+ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"
 ARG BCFTOOLS_VERSION="1.18"
@@ -53,14 +53,12 @@ RUN apt-get update && \
     autoconf \
     automake \
     build-essential \
-    less \
     libtool \
     pkg-config \
     python3-sphinx \
-    ssh \
-    libjansson-dev \
     libbz2-dev \
     libcurl3-dev \
+    libjansson-dev \
     liblzma-dev \
     zlib1g-dev
 
@@ -129,15 +127,13 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
     tee /etc/apt/sources.list.d/renci-irods.list && \
     apt-get update && \ 
     apt-get install -q -y --no-install-recommends \
-    gnuplot \
     irods-icommands="${IRODS_VERSION}-1~$(lsb_release -sc)" \
     irods-runtime="${IRODS_VERSION}-1~$(lsb_release -sc)" \
     jq \
-    libjansson4 \
     libbz2-1.0 \
     libcurl3 \
+    libjansson4 \
     liblzma5 \
-    perl \
     zlib1g \
     unattended-upgrades && \
     unattended-upgrade -v && \


### PR DESCRIPTION
Update to baton 4.2.0, which builds on iRODS 4.2.7 through to 4.3-nightly (except 4.3.0).

Remove some unnecessary tools from the Docker builds.