### PR TITLE
Force docker buildx to use the default builder

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -80,6 +80,12 @@ jobs:
       - name: "Build and push Docker images"
         run: |
             cd docker
+
+            # Use the default builder because buildx cannot currently build on a base image
+            # that it has just built. See https://github.com/docker/buildx/issues/1453
+            # We still need buildx for its --build-context feature.
+            docker buildx use default
+
             make GITHUB_ACTIONS=${GITHUB_ACTIONS} GITHUB_REPOSITORY_OWNER=${{ github.repository_owner }}
 
             docker image prune --force

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,6 +46,11 @@ jobs:
         run: |
             TAG=$(git describe --always --tags)
 
+            # Use the default builder because buildx cannot currently build on a base image
+            # that it has just built. See https://github.com/docker/buildx/issues/1453
+            # We still need buildx for its --build-context feature.
+            docker buildx use default
+
             cd docker
             make GITHUB_ACTIONS=${GITHUB_ACTIONS} GITHUB_REPOSITORY_OWNER=${{ github.repository_owner }} ${{ env.SERVER_IMAGE }}.${TAG}
             make GITHUB_ACTIONS=${GITHUB_ACTIONS} GITHUB_REPOSITORY_OWNER=${{ github.repository_owner }} ${{ env.CLIENT_IMAGE }}.${TAG}

--- a/docker/irods_clients/ubuntu/16.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/16.04/Dockerfile
@@ -3,7 +3,10 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM $BASE_IMAGE as installer
 
+# This default is the latest usable version
 ARG IRODS_VERSION="4.2.7"
+
+# These defaults are the latest usable versions
 ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"

--- a/docker/irods_clients/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/22.04/Dockerfile
@@ -4,6 +4,8 @@ ARG BASE_IMAGE=ubuntu:22.04
 FROM $BASE_IMAGE as installer
 
 ARG IRODS_VERSION="4.3-nightly"
+
+# These defaults are the latest usable versions
 ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"

--- a/docker/irods_clients/ubuntu/Dockerfile
+++ b/docker/irods_clients/ubuntu/Dockerfile
@@ -3,8 +3,10 @@
 ARG BASE_IMAGE=ubuntu:18.04
 FROM $BASE_IMAGE as installer
 
-# Other iRODS versions available on bionic are 4.3.0
+# This default is the latest usable version
 ARG IRODS_VERSION="4.2.11"
+
+# These defaults are the latest usable versions
 ARG BATON_VERSION="4.2.0"
 ARG HTSLIB_VERSION="1.18"
 ARG SAMTOOLS_VERSION="1.18"

--- a/docker/irods_clients_dev/ubuntu/16.04/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/16.04/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=ubuntu:16.04
 FROM $BASE_IMAGE
 
+# This default is the latest usable version
 ARG IRODS_VERSION="4.2.7"
 
 COPY . /opt/docker/irods_clients_dev

--- a/docker/irods_clients_dev/ubuntu/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=ubuntu:18.04
 FROM $BASE_IMAGE
 
-# Other versions available on bionic are 4.3.0
-ARG IRODS_VERSION="4.2.11"
+# This default is is latest usable version
+ARG IRODS_VERSION="4.2.12" 
 
 COPY . /opt/docker/irods_clients_dev
 


### PR DESCRIPTION
This is to work around the issue that docker buildx cannot build ona base image that it has just built. See https://github.com/docker/buildx/issues/1453