### PR TITLE
Use the full SHA when declaring an Action version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: "Free disk space on the runner"
-        uses: jlumbroso/free-disk-space@f68fdb7  # v1.3.0
+        uses: jlumbroso/free-disk-space@f68fdb76e2ea636224182cfb7377ff9a1708f9b8  # v1.3.0
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
GitHub requires the full SHA, not a shortened version.