### PR TITLE
Update nightly package names for 4.3.1 tag

### DIFF
--- a/docker/irods/ubuntu/22.04/Dockerfile
+++ b/docker/irods/ubuntu/22.04/Dockerfile
@@ -41,11 +41,11 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 ENV NIGHTLY_URL_BASE=https://github.com/wtsi-npg/irods_development_environment/releases/download/nightly/
 
 RUN curl -sSL \
-    -O ${NIGHTLY_URL_BASE}irods-database-plugin-postgres_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-server_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.0-1.jammy_amd64.deb
+    -O ${NIGHTLY_URL_BASE}irods-database-plugin-postgres_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-server_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.1-0.jammy_amd64.deb
 
 RUN ls -l && apt-get install -y ./*.deb
 

--- a/docker/irods_clients/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/22.04/Dockerfile
@@ -40,9 +40,9 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 ENV NIGHTLY_URL_BASE=https://github.com/wtsi-npg/irods_development_environment/releases/download/nightly/
 
 RUN curl -sSL \
-    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.0-1.jammy_amd64.deb
+    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.1-0.jammy_amd64.deb
 
 RUN ls -l && apt-get install -y ./*.deb
 
@@ -130,8 +130,8 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 ENV NIGHTLY_URL_BASE=https://github.com/wtsi-npg/irods_development_environment/releases/download/nightly/
 
 RUN curl -sSL \
-    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.0-1.jammy_amd64.deb
+    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.1-0.jammy_amd64.deb
 
 RUN ls -l && apt-get install -y ./*.deb
 

--- a/docker/irods_clients_dev/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/22.04/Dockerfile
@@ -29,11 +29,11 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 ENV NIGHTLY_URL_BASE=https://github.com/wtsi-npg/irods_development_environment/releases/download/nightly/
 
 RUN curl -sSL \
-    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.0-1.jammy_amd64.deb \
-    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.0-1.jammy_amd64.deb
+    -O ${NIGHTLY_URL_BASE}irods-dev_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.1-0.jammy_amd64.deb \
+    -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.1-0.jammy_amd64.deb
 
-RUN ls -l && apt-get install -y ./*.deb
+RUN ls -l && apt-get update && apt-get install -y ./*.deb
 
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \


### PR DESCRIPTION
The 4-3-stable branch has been tagged upstream as 4.3.1, which changes the name of the packages created.