### PR TITLE
add plot-ampliconstats to irods_clients manifest

### DIFF
--- a/docker/irods_clients/manifest.txt
+++ b/docker/irods_clients/manifest.txt
@@ -60,4 +60,5 @@ iunreg
 iuserinfo
 ixmsg
 izonereport
+plot-ampliconstats
 samtools


### PR DESCRIPTION
The application is part of the samtools suite. It can be used both as `samtools ampliconstats` or `plot-ampliconstats` so adding the second for compatibility with pipelines