### PR TITLE
Add iRODS 4.3.3 and remove iRODS 4.3.0

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,24 +19,28 @@ image_names := ub-16.04-base ub-18.04-base ub-22.04-base
 image_names += ub-16.04-irods-4.2.7
 image_names += ub-18.04-irods-4.2.11
 image_names += ub-18.04-irods-4.2.12
-image_names += ub-18.04-irods-4.3.0
+
 image_names += ub-22.04-irods-4.3.1
 image_names += ub-22.04-irods-4.3.2
+image_names += ub-22.04-irods-4.3.3
 # image_names += ub-22.04-irods-4.3-nightly
 
 image_names += ub-16.04-irods-clients-dev-4.2.7
 image_names += ub-18.04-irods-clients-dev-4.2.11
 image_names += ub-18.04-irods-clients-dev-4.2.12
-image_names += ub-18.04-irods-clients-dev-4.3.0
+
 image_names += ub-22.04-irods-clients-dev-4.3.1
 image_names += ub-22.04-irods-clients-dev-4.3.2
+image_names += ub-22.04-irods-clients-dev-4.3.3
 # image_names += ub-22.04-irods-clients-dev-4.3-nightly
 
 image_names += ub-16.04-irods-clients-4.2.7
 image_names += ub-18.04-irods-clients-4.2.11
 image_names += ub-18.04-irods-clients-4.2.12
+
 image_names += ub-22.04-irods-clients-4.3.1
 image_names += ub-22.04-irods-clients-4.3.2
+image_names += ub-22.04-irods-clients-4.3.3
 # image_names += ub-22.04-irods-clients-4.3-nightly
 
 git_url=$(shell git remote get-url origin)
@@ -135,21 +139,6 @@ ub-18.04-irods-4.2.12.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-4.2.12:$(TAG) --file $< ./irods
 	touch $@
 
-ub-18.04-irods-4.3.0.$(TAG): irods/ubuntu/18.04/Dockerfile ub-18.04-base.$(TAG)
-	docker buildx build $(DOCKER_ARGS) \
-	--load \
-	--build-arg BASE_IMAGE=$(DOCKER_PREFIX)/ub-18.04-base \
-	--build-arg IRODS_VERSION=4.3.0 \
-	--label org.opencontainers.image.title="iRODS 4.3.0 server, Ubuntu 18.04" \
-	--label org.opencontainers.image.source=$(git_url) \
-	--label org.opencontainers.image.revision=$(git_commit) \
-	--label org.opencontainers.image.version=$(TAG) \
-	--label org.opencontainers.image.created=$(NOW) \
-	--label org.opencontainers.image.vendor=npg.sanger.ac.uk \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-4.3.0:latest \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-4.3.0:$(TAG) --file $< ./irods
-	touch $@
-
 ub-22.04-irods-4.3.1.$(TAG): irods/ubuntu/22.04/Dockerfile ub-22.04-base.$(TAG)
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
@@ -180,6 +169,20 @@ ub-22.04-irods-4.3.2.$(TAG): irods/ubuntu/22.04/Dockerfile ub-22.04-base.$(TAG)
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-4.3.2:$(TAG) --file $< ./irods
 	touch $@
 
+ub-22.04-irods-4.3.3.$(TAG): irods/ubuntu/22.04/Dockerfile ub-22.04-base.$(TAG)
+	docker buildx build $(DOCKER_ARGS) \
+	--load \
+	--build-arg BASE_IMAGE=$(DOCKER_PREFIX)/ub-22.04-base \
+	--build-arg IRODS_VERSION=4.3.2 \
+	--label org.opencontainers.image.title="iRODS 4.3.3 server, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-4.3.3:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-4.3.3:$(TAG) --file $< ./irods
+	touch $@
+
 ub-22.04-irods-4.3-nightly.$(TAG): irods/ubuntu/22.04/Dockerfile.nightly ub-22.04-base.$(TAG)
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
@@ -203,7 +206,7 @@ ub-16.04-irods-clients-4.2.7.$(TAG): irods_clients/ubuntu/16.04/Dockerfile ub-16
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.2.7 \
-	--build-arg BATON_VERSION=4.2.1 \
+	--build-arg BATON_VERSION=4.2.2 \
 	--build-arg HTSLIB_VERSION=1.20 \
 	--build-arg SAMTOOLS_VERSION=1.20 \
 	--build-arg BCFTOOLS_VERSION=1.20 \
@@ -225,7 +228,7 @@ ub-18.04-irods-clients-4.2.11.$(TAG): irods_clients/ubuntu/18.04/Dockerfile ub-1
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.2.11 \
-	--build-arg BATON_VERSION=4.2.1 \
+	--build-arg BATON_VERSION=4.2.2 \
 	--build-arg HTSLIB_VERSION=1.20 \
 	--build-arg SAMTOOLS_VERSION=1.20 \
 	--build-arg BCFTOOLS_VERSION=1.20 \
@@ -271,7 +274,7 @@ ub-22.04-irods-clients-4.3.1.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.3.1 \
-	--build-arg BATON_VERSION=4.2.1 \
+	--build-arg BATON_VERSION=4.2.2 \
 	--build-arg HTSLIB_VERSION=1.20 \
 	--build-arg SAMTOOLS_VERSION=1.20 \
 	--build-arg BCFTOOLS_VERSION=1.20 \
@@ -294,7 +297,7 @@ ub-22.04-irods-clients-4.3.2.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.3.2 \
-	--build-arg BATON_VERSION=4.2.1 \
+	--build-arg BATON_VERSION=4.2.2 \
 	--build-arg HTSLIB_VERSION=1.20 \
 	--build-arg SAMTOOLS_VERSION=1.20 \
 	--build-arg BCFTOOLS_VERSION=1.20 \
@@ -308,6 +311,28 @@ ub-22.04-irods-clients-4.3.2.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-4.3.2:$(TAG) --file $< ./irods_clients
 	touch $@
 
+ub-22.04-irods-clients-4.3.3.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
+	docker buildx build $(DOCKER_ARGS) \
+	--load \
+	--build-context singularity=../singularity \
+	--build-arg DOCKER_PREFIX=$(DOCKER_PREFIX) \
+	--build-arg BASE_IMAGE=$(DOCKER_PREFIX)/ub-22.04-base \
+	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
+	--build-arg DOCKER_TAG=$(TAG) \
+	--build-arg IRODS_VERSION=4.3.3 \
+	--build-arg BATON_VERSION=4.2.2 \
+	--build-arg HTSLIB_VERSION=1.20 \
+	--build-arg SAMTOOLS_VERSION=1.20 \
+	--build-arg BCFTOOLS_VERSION=1.20 \
+	--label org.opencontainers.image.title="iRODS 4.3.3 clients, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-4.3.3:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-4.3.3:$(TAG) --file $< ./irods_clients
+	touch $@
+
 ub-22.04-irods-clients-4.3-nightly.$(TAG): irods_clients/ubuntu/22.04/Dockerfile.nightly
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
@@ -317,7 +342,7 @@ ub-22.04-irods-clients-4.3-nightly.$(TAG): irods_clients/ubuntu/22.04/Dockerfile
 	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
 	--build-arg DOCKER_TAG=$(TAG) \
 	--build-arg IRODS_VERSION=4.3-nightly \
-	--build-arg BATON_VERSION=4.2.1 \
+	--build-arg BATON_VERSION=4.2.2 \
 	--build-arg HTSLIB_VERSION=1.20 \
 	--build-arg SAMTOOLS_VERSION=1.20 \
 	--build-arg BCFTOOLS_VERSION=1.20 \
@@ -385,24 +410,6 @@ ub-18.04-irods-clients-dev-4.2.12.$(TAG): irods_clients_dev/ubuntu/18.04/Dockerf
 	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-dev-4.2.12:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
-ub-18.04-irods-clients-dev-4.3.0.$(TAG): irods_clients_dev/ubuntu/18.04/Dockerfile
-	docker buildx build $(DOCKER_ARGS) \
-	--load \
-	--build-context singularity=../singularity \
-	--build-arg BASE_IMAGE=ubuntu:18.04 \
-	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
-	--build-arg DOCKER_TAG=$(TAG) \
-	--build-arg IRODS_VERSION=4.3.0 \
-	--label org.opencontainers.image.title="iRODS 4.3.0 client development, Ubuntu 18.04" \
-	--label org.opencontainers.image.source=$(git_url) \
-	--label org.opencontainers.image.revision=$(git_commit) \
-	--label org.opencontainers.image.version=$(TAG) \
-	--label org.opencontainers.image.created=$(NOW) \
-	--label org.opencontainers.image.vendor=npg.sanger.ac.uk \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:latest \
-	--tag $(DOCKER_PREFIX)/ub-18.04-irods-clients-dev-4.3.0:$(TAG) --file $< ./irods_clients_dev
-	touch $@
-
 ub-22.04-irods-clients-dev-4.3.1.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfile
 	docker buildx build $(DOCKER_ARGS) \
 	--load \
@@ -439,6 +446,24 @@ ub-22.04-irods-clients-dev-4.3.2.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfi
 	--label org.opencontainers.image.vendor=npg.sanger.ac.uk \
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3.2:latest \
 	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3.2:$(TAG) --file $< ./irods_clients_dev
+	touch $@
+
+ub-22.04-irods-clients-dev-4.3.3.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfile
+	docker buildx build $(DOCKER_ARGS) \
+	--load \
+	--build-context singularity=../singularity \
+	--build-arg DOCKER_PREFIX=$(DOCKER_PREFIX) \
+	--build-arg BASE_IMAGE=ubuntu:22.04 \
+	--build-arg IRODS_VERSION=4.3.3 \
+	--build-arg DOCKER_IMAGE=$(subst .$(TAG),,$@) \
+	--build-arg DOCKER_TAG=$(TAG) \
+	--label org.opencontainers.image.title="iRODS 4.3.3 client development, Ubuntu 22.04" \
+	--label org.opencontainers.image.source=$(git_url) \
+	--label org.opencontainers.image.revision=$(git_commit) \
+	--label org.opencontainers.image.version=$(TAG) \
+	--label org.opencontainers.image.created=$(NOW) \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3.3:latest \
+	--tag $(DOCKER_PREFIX)/ub-22.04-irods-clients-dev-4.3.3:$(TAG) --file $< ./irods_clients_dev
 	touch $@
 
 ub-22.04-irods-clients-dev-4.3-nightly.$(TAG): irods_clients_dev/ubuntu/22.04/Dockerfile.nightly

--- a/docker/irods/scripts/configure_irods.sh
+++ b/docker/irods/scripts/configure_irods.sh
@@ -30,6 +30,12 @@ case "$IRODS_VERSION" in
         python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
         ;;
     4.3.2)
+        patch /var/lib/irods/scripts/irods/controller.py /opt/docker/irods/patches/patch_controller.diff
+        # Logging has been changed to use rsyslog. A potential enhancement is to configure that here.
+        python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
+        ;;
+    4.3.3)
+        patch /var/lib/irods/scripts/irods/controller.py /opt/docker/irods/patches/patch_controller.diff
         # Logging has been changed to use rsyslog. A potential enhancement is to configure that here.
         python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
         ;;

--- a/docker/irods/ubuntu/16.04/Dockerfile
+++ b/docker/irods/ubuntu/16.04/Dockerfile
@@ -4,14 +4,15 @@ FROM $BASE_IMAGE
 # This default is the latest usable version
 ARG IRODS_VERSION="4.2.7"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 WORKDIR /opt/docker/irods
 
 COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
@@ -29,7 +30,8 @@ RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \

--- a/docker/irods/ubuntu/18.04/Dockerfile
+++ b/docker/irods/ubuntu/18.04/Dockerfile
@@ -6,14 +6,15 @@ ARG IRODS_VERSION="4.3.1"
 # This is the Debian package revision number
 ARG IRODS_REVISION="1"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 WORKDIR /opt/docker/irods
 
 COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -33,7 +34,8 @@ RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \

--- a/docker/irods/ubuntu/22.04/Dockerfile
+++ b/docker/irods/ubuntu/22.04/Dockerfile
@@ -6,14 +6,15 @@ ARG IRODS_VERSION="4.3.1"
 # This is the Debian package revision number
 ARG IRODS_REVISION="0"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 WORKDIR /opt/docker/irods
 
 COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -33,7 +34,8 @@ RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt $(lsb_release -sc) main" | \

--- a/docker/irods/ubuntu/22.04/Dockerfile.nightly
+++ b/docker/irods/ubuntu/22.04/Dockerfile.nightly
@@ -3,14 +3,15 @@ FROM $BASE_IMAGE
 
 ARG IRODS_VERSION="nightly"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 WORKDIR /opt/docker/irods
 
 COPY ./scripts/*.sh ./scripts/
 COPY ./config/* ./config/
 COPY ./patches/* ./patches/
 
-RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \

--- a/docker/irods_clients/ubuntu/16.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/16.04/Dockerfile
@@ -13,7 +13,7 @@ ARG BCFTOOLS_VERSION="1.18"
 ARG HTSLIB_PLUGINS_VERSION="201712"
 
 ARG BASE_IMAGE=ubuntu:16.04
-FROM $BASE_IMAGE as installer
+FROM $BASE_IMAGE AS installer
 
 ARG IRODS_VERSION
 ARG BATON_VERSION
@@ -22,10 +22,11 @@ ARG SAMTOOLS_VERSION
 ARG BCFTOOLS_VERSION
 ARG HTSLIB_PLUGINS_VERSION
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     apt-utils \
@@ -75,20 +76,21 @@ RUN apt-get update && \
     zlib1g-dev
 
 ENV CPPFLAGS="-I/usr/include/irods"
+ENV CPU_COUNT=4
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz" && \
     tar xfz baton-${BATON_VERSION}.tar.gz && \
     cd baton-${BATON_VERSION} && \
     ./configure && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" && \
     tar xfj htslib-${HTSLIB_VERSION}.tar.bz2 && \
     cd htslib-${HTSLIB_VERSION} && \
     ./configure --enable-plugins --without-curses && \
-    make install && \
+    make -j ${CPU_COUNT} install && \
     ldconfig
 
 RUN cd /tmp && \
@@ -96,19 +98,19 @@ RUN cd /tmp && \
     tar xfj samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
     cd samtools-${SAMTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2" && \
     tar xfj bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     git clone --depth 1 --branch ${HTSLIB_PLUGINS_VERSION} "https://github.com/samtools/htslib-plugins.git" && \
     cd htslib-plugins && \
-    make install
+    make -j ${CPU_COUNT} install
 
 FROM $BASE_IMAGE 
 
@@ -116,8 +118,9 @@ ARG DOCKER_IMAGE
 ARG DOCKER_TAG
 ARG IRODS_VERSION
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     apt-utils \

--- a/docker/irods_clients/ubuntu/18.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/18.04/Dockerfile
@@ -15,7 +15,7 @@ ARG BCFTOOLS_VERSION="1.18"
 ARG HTSLIB_PLUGINS_VERSION="201712"
 
 ARG BASE_IMAGE=ubuntu:18.04
-FROM $BASE_IMAGE as installer
+FROM $BASE_IMAGE AS installer
 
 ARG IRODS_VERSION
 ARG IRODS_REVISION
@@ -25,10 +25,11 @@ ARG SAMTOOLS_VERSION
 ARG BCFTOOLS_VERSION
 ARG HTSLIB_PLUGINS_VERSION
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -43,7 +44,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -77,20 +79,21 @@ RUN apt-get update && \
     zlib1g-dev
 
 ENV CPPFLAGS="-I/usr/include/irods"
+ENV CPU_COUNT=4
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz" && \
     tar xfz baton-${BATON_VERSION}.tar.gz && \
     cd baton-${BATON_VERSION} && \
     ./configure && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" && \
     tar xfj htslib-${HTSLIB_VERSION}.tar.bz2 && \
     cd htslib-${HTSLIB_VERSION} && \
     ./configure --enable-plugins --without-curses && \
-    make install && \
+    make -j ${CPU_COUNT} install && \
     ldconfig
 
 RUN cd /tmp && \
@@ -98,14 +101,14 @@ RUN cd /tmp && \
     tar xfj samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
     cd samtools-${SAMTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2" && \
     tar xfj bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
-    ./configure --with-htslib=system --without-curses && \
-    make install
+    ./configure --with-htslib=system --without-curses || cat config.log
+    # make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     git clone --depth 1 --branch ${HTSLIB_PLUGINS_VERSION} "https://github.com/samtools/htslib-plugins.git" && \
@@ -119,8 +122,9 @@ ARG DOCKER_TAG
 ARG IRODS_VERSION
 ARG IRODS_REVISION
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -135,7 +139,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\

--- a/docker/irods_clients/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients/ubuntu/22.04/Dockerfile
@@ -15,7 +15,7 @@ ARG BCFTOOLS_VERSION="1.18"
 ARG HTSLIB_PLUGINS_VERSION="201712"
 
 ARG BASE_IMAGE=ubuntu:22.04
-FROM $BASE_IMAGE as installer
+FROM $BASE_IMAGE AS installer
 
 # Use defaults
 ARG IRODS_VERSION
@@ -26,10 +26,11 @@ ARG SAMTOOLS_VERSION
 ARG BCFTOOLS_VERSION
 ARG HTSLIB_PLUGINS_VERSION
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -44,7 +45,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -71,20 +73,21 @@ RUN apt-get update && \
     zlib1g-dev
 
 ENV CPPFLAGS="-I/usr/include/irods"
+ENV CPU_COUNT=4
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz" && \
     tar xfz baton-${BATON_VERSION}.tar.gz && \
     cd baton-${BATON_VERSION} && \
     ./configure && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" && \
     tar xfj htslib-${HTSLIB_VERSION}.tar.bz2 && \
     cd htslib-${HTSLIB_VERSION} && \
     ./configure --enable-plugins --without-curses && \
-    make install && \
+    make -j ${CPU_COUNT} install && \
     ldconfig
 
 RUN cd /tmp && \
@@ -92,19 +95,19 @@ RUN cd /tmp && \
     tar xfj samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
     cd samtools-${SAMTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2" && \
     tar xfj bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     git clone --depth 1 --branch ${HTSLIB_PLUGINS_VERSION} "https://github.com/samtools/htslib-plugins.git" && \
     cd htslib-plugins && \
-    make install
+    make -j ${CPU_COUNT} install
 
 FROM $BASE_IMAGE 
 
@@ -113,8 +116,9 @@ ARG DOCKER_TAG
 ARG IRODS_VERSION
 ARG IRODS_REVISION
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \

--- a/docker/irods_clients/ubuntu/22.04/Dockerfile.nightly
+++ b/docker/irods_clients/ubuntu/22.04/Dockerfile.nightly
@@ -12,7 +12,7 @@ ARG BCFTOOLS_VERSION="1.18"
 ARG HTSLIB_PLUGINS_VERSION="201712"
 
 ARG BASE_IMAGE=ubuntu:22.04
-FROM $BASE_IMAGE as installer
+FROM $BASE_IMAGE AS installer
 
 ARG IRODS_VERSION
 ARG BATON_VERSION
@@ -21,10 +21,11 @@ ARG SAMTOOLS_VERSION
 ARG BCFTOOLS_VERSION
 ARG HTSLIB_PLUGINS_VERSION
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -39,7 +40,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -72,20 +74,21 @@ RUN apt-get update && \
     zlib1g-dev
 
 ENV CPPFLAGS="-I/usr/include/irods"
+ENV CPU_COUNT=4
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/wtsi-npg/baton/releases/download/${BATON_VERSION}/baton-${BATON_VERSION}.tar.gz" && \
     tar xfz baton-${BATON_VERSION}.tar.gz && \
     cd baton-${BATON_VERSION} && \
     ./configure && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2" && \
     tar xfj htslib-${HTSLIB_VERSION}.tar.bz2 && \
     cd htslib-${HTSLIB_VERSION} && \
     ./configure --enable-plugins --without-curses && \
-    make install && \
+    make -j ${CPU_COUNT} install && \
     ldconfig
 
 RUN cd /tmp && \
@@ -93,19 +96,19 @@ RUN cd /tmp && \
     tar xfj samtools-${SAMTOOLS_VERSION}.tar.bz2 && \
     cd samtools-${SAMTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     curl -sSL -O "https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2" && \
     tar xfj bcftools-${BCFTOOLS_VERSION}.tar.bz2 && \
     cd bcftools-${BCFTOOLS_VERSION} && \
     ./configure --with-htslib=system --without-curses && \
-    make install
+    make -j ${CPU_COUNT} install
 
 RUN cd /tmp && \
     git clone --depth 1 --branch ${HTSLIB_PLUGINS_VERSION} "https://github.com/samtools/htslib-plugins.git" && \
     cd htslib-plugins && \
-    make install
+    make -j ${CPU_COUNT} install
 
 FROM $BASE_IMAGE 
 
@@ -113,8 +116,9 @@ ARG DOCKER_IMAGE
 ARG DOCKER_TAG
 ARG IRODS_VERSION
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -129,7 +133,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\

--- a/docker/irods_clients_dev/ubuntu/16.04/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/16.04/Dockerfile
@@ -4,10 +4,11 @@ FROM $BASE_IMAGE
 # The latest usable version
 ARG IRODS_VERSION="4.2.7"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients_dev
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-transport-https \
     apt-utils \
@@ -23,7 +24,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -36,10 +38,7 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 
 RUN apt-key add - < /opt/docker/irods_clients_dev/keys/git-core-ppa.asc && \
     echo "deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu $(lsb_release -sc) main" |\
-    tee /etc/apt/sources.list.d/git-core.list && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends \
-    git
+    tee /etc/apt/sources.list.d/git-core.list
 
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
@@ -49,6 +48,7 @@ RUN apt-get update && \
     check \
     cmake \
     gdb \
+    git \
     jq \
     lcov \
     less \

--- a/docker/irods_clients_dev/ubuntu/18.04/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/18.04/Dockerfile
@@ -6,10 +6,11 @@ ARG IRODS_VERSION="4.3.1"
 # The Debian package revision number
 ARG IRODS_REVISION="1"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients_dev
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -24,7 +25,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -37,10 +39,7 @@ RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - &
 
 RUN apt-key add - < /opt/docker/irods_clients_dev/keys/git-core-ppa.asc && \
     echo "deb https://ppa.launchpadcontent.net/git-core/ppa/ubuntu $(lsb_release -sc) main" |\
-    tee /etc/apt/sources.list.d/git-core.list && \
-    apt-get update && \
-    apt-get install -q -y --no-install-recommends \
-    git
+    tee /etc/apt/sources.list.d/git-core.list
 
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
@@ -50,6 +49,7 @@ RUN apt-get update && \
     check \
     cmake \
     gdb \
+    git \
     jq \
     lcov \
     less \

--- a/docker/irods_clients_dev/ubuntu/22.04/Dockerfile
+++ b/docker/irods_clients_dev/ubuntu/22.04/Dockerfile
@@ -6,10 +6,11 @@ ARG IRODS_VERSION="4.3.1"
 # The Debian package revision number
 ARG IRODS_REVISION="0"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 COPY . /opt/docker/irods_clients_dev
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -24,7 +25,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\

--- a/docker/irods_clients_dev/ubuntu/22.04/Dockerfile.nightly
+++ b/docker/irods_clients_dev/ubuntu/22.04/Dockerfile.nightly
@@ -3,8 +3,9 @@ FROM $BASE_IMAGE
 
 ARG IRODS_VERSION="4.3-nightly"
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \
     apt-utils \
     ca-certificates \
@@ -19,7 +20,8 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 ENV LANG=en_GB.UTF-8 \
     LANGUAGE=en_GB \
-    LC_ALL=en_GB.UTF-8
+    LC_ALL=en_GB.UTF-8 \
+    TZ=/Etc/UTC
 
 RUN curl -sSL https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" |\
@@ -33,7 +35,7 @@ RUN curl -sSL \
     -O ${NIGHTLY_URL_BASE}irods-runtime_4.3.1-0.jammy_amd64.deb \
     -O ${NIGHTLY_URL_BASE}irods-icommands_4.3.1-0.jammy_amd64.deb
 
-RUN ls -l && apt-get update && apt-get install -y ./*.deb
+RUN ls -l && apt-get update && apt-get install -y ./*.deb && rm ./*.deb
 
 RUN apt-get update && \
     apt-get install -q -y --no-install-recommends \


### PR DESCRIPTION
4.3.3 is the latest release, while 4.3.0 is has broken C API headers, so is not usable by us.