### PR TITLE
Remove creation of an Exodus bundle

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,12 +5,8 @@ on:
     tags:
       - "*"
 
-env:
-  BUNDLE_NAME: bundle-ub-16.04-irods-clients-4.2.7.tgz
-
 jobs:
-
-  release_variables:
+  release:
     runs-on: ubuntu-latest
 
     defaults:
@@ -36,19 +32,24 @@ jobs:
           echo 'RELEASE_VERSION='$(git describe --always --tags) >> $GITHUB_ENV
           echo 'MASTER_SHA='$(git rev-parse origin/master) >> $GITHUB_ENV
 
+      - name: "Create Release"
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          name: ${{ env.RELEASE_VERSION }}
+          prerelease: ${{ !(github.sha == env.MASTER_SHA) }}
+          generateReleaseNotes: true
+
     outputs:
       isRelease: ${{ github.sha == env.MASTER_SHA }}
-      preRelease: ${{ !(github.sha == env.MASTER_SHA) }}
-      releaseVersion: ${{ env.RELEASE_VERSION }}
 
   deploy:
     runs-on: ubuntu-latest
 
-    needs: release_variables
+    needs: release
 
     # Workaround for https://github.com/actions/runner/issues/1483
     # Actions coerces boolean to string
-    if: needs.release_variables.outputs.isRelease == 'true'
+    if: needs.release.outputs.isRelease == 'true'
 
     steps:
       - name: "Free disk space on the runner"
@@ -102,59 +103,3 @@ jobs:
             docker images
 
             make push GITHUB_ACTIONS=${GITHUB_ACTIONS} GITHUB_REPOSITORY_OWNER=${{ github.repository_owner }}
-
-  bundle:
-    runs-on: ubuntu-latest
-    container: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-4.2.7:latest"
-
-    needs: deploy
-
-    if: always()
-
-    steps:
-    - name: "Install exodus"
-      run: |
-        apt-get update
-        apt-get install -q -y python3-pip
-        pip3 install exodus-bundler
-
-    - name: "Bundle clients"
-
-      run: exodus --tarball --add /usr/lib/irods/plugins/ --add /lib/x86_64-linux-gnu/ --output $BUNDLE_NAME /usr/local/bin/baton-* /usr/bin/ils /usr/bin/iinit /usr/bin/imeta
-
-    - name: "Upload bundle"
-      uses: actions/upload-artifact@v4
-      with:
-        name: client_bundle
-        path: ${{ env.BUNDLE_NAME }}
-
-  release:
-    runs-on: ubuntu-latest
-
-    needs: [release_variables, bundle]
-
-    if: always()
-
-    defaults:
-      run:
-        shell: bash -l -e -o pipefail {0}
-
-    steps:
-
-      - name: "Download artifact"
-        uses: actions/download-artifact@v4
-        with:
-          name: client_bundle
-
-      - name: "Create Release"
-        uses: ncipollo/release-action@v1.14.0
-        with:
-          name: ${{ env.NAME }}
-          prerelease: ${{ env.PRERELEASE }}
-          artifacts: ${{ env.BUNDLE_NAME }}
-          removeArtifacts: true
-          artifactErrorsFailBuild: true
-          generateReleaseNotes: true
-        env:
-          NAME: ${{ needs.release_variables.outputs.releaseVersion }}
-          PRERELEASE: ${{ needs.release_variables.outputs.preRelease }}


### PR DESCRIPTION
The bundle is no longer needed, now that we can use Docker on the instrument.

The bundle build has been broken by changes in Actions (Node.js) and it's more cost-effective to remove than fix.