### PR TITLE
Fix the controller patch applied to iRODS 4.3.2

### DIFF
--- a/docker/irods/scripts/configure_irods.sh
+++ b/docker/irods/scripts/configure_irods.sh
@@ -30,12 +30,10 @@ case "$IRODS_VERSION" in
         python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
         ;;
     4.3.2)
-        patch /var/lib/irods/scripts/irods/controller.py /opt/docker/irods/patches/patch_controller.diff
         # Logging has been changed to use rsyslog. A potential enhancement is to configure that here.
         python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
         ;;
     4.3.3)
-        patch /var/lib/irods/scripts/irods/controller.py /opt/docker/irods/patches/patch_controller.diff
         # Logging has been changed to use rsyslog. A potential enhancement is to configure that here.
         python3 /var/lib/irods/scripts/setup_irods.py < /opt/docker/irods/config/4.3.x.setup_irods.py.in
         ;;


### PR DESCRIPTION
This patch was applied to get the controller working under Rosetta 2 emulation on macOS. Rosetta leaks its presence into the container and breaks Python psutil (/run/rosetta/rosetta appears instead of the true process).

However, this particular patch then breaks on Linux.